### PR TITLE
Rename codegenerator

### DIFF
--- a/src/backend/codegen/CMakeLists.txt
+++ b/src/backend/codegen/CMakeLists.txt
@@ -113,7 +113,7 @@ include_directories(${CLANG_INCLUDE_DIRS})
 # Core codegen library.
 add_library(gpcodegen SHARED
             utils/clang_compiler.cc
-            utils/code_generator.cc
+            utils/codegen_utils.cc
             ${codegen_tmpfile_sources})
 if(APPLE)
   set(WL_START_GROUP "")
@@ -166,7 +166,7 @@ add_custom_target(unittest-check ${CMAKE_CTEST_COMMAND})
 
 SET(TEST_SOURCES
     tests/clang_compiler_unittest.cc
-    tests/code_generator_unittest.cc
+    tests/codegen_utils_unittest.cc
     tests/instance_method_wrappers_unittest.cc)
 
 # Googletest framework for tests.

--- a/src/backend/codegen/include/codegen/utils/annotated_type.h
+++ b/src/backend/codegen/include/codegen/utils/annotated_type.h
@@ -43,7 +43,7 @@ struct AnnotatedType {
    *
    * @tparam T A C++ scalar type.
    * @param llvm_type The type's representation in LLVM, obtained by calling
-   *        CodeGenerator::GetType<T>() or similar.
+   *        CodeGenUtils::GetType<T>() or similar.
    * @return An AnnotatedType that includes additional information about T not
    *         captured by the llvm::Type.
    **/
@@ -67,7 +67,7 @@ struct AnnotatedType {
    * @tparam T A C++ void pointer type with any combination of const and/or
    *         volatile qualifiers.
    * @param llvm_type The type's representation in LLVM, obtained by calling
-   *        CodeGenerator::GetType<T>() or similar.
+   *        CodeGenUtils::GetType<T>() or similar.
    * @return An AnnotatedType that includes additional information about the
    *         void pointer type T not captured by the llvm::Type.
    **/

--- a/src/backend/codegen/include/codegen/utils/annotated_type.h
+++ b/src/backend/codegen/include/codegen/utils/annotated_type.h
@@ -43,7 +43,7 @@ struct AnnotatedType {
    *
    * @tparam T A C++ scalar type.
    * @param llvm_type The type's representation in LLVM, obtained by calling
-   *        CodeGenUtils::GetType<T>() or similar.
+   *        CodegenUtils::GetType<T>() or similar.
    * @return An AnnotatedType that includes additional information about T not
    *         captured by the llvm::Type.
    **/
@@ -67,7 +67,7 @@ struct AnnotatedType {
    * @tparam T A C++ void pointer type with any combination of const and/or
    *         volatile qualifiers.
    * @param llvm_type The type's representation in LLVM, obtained by calling
-   *        CodeGenUtils::GetType<T>() or similar.
+   *        CodegenUtils::GetType<T>() or similar.
    * @return An AnnotatedType that includes additional information about the
    *         void pointer type T not captured by the llvm::Type.
    **/

--- a/src/backend/codegen/include/codegen/utils/clang_compiler.h
+++ b/src/backend/codegen/include/codegen/utils/clang_compiler.h
@@ -22,8 +22,8 @@
 #include <string>
 #include <type_traits>
 
-#include "codegen/utils/code_generator.h"
 #include "codegen/utils/macros.h"
+#include "codegen/utils/codegen_utils.h"
 
 namespace llvm { class Twine; }
 
@@ -44,10 +44,10 @@ struct AnnotatedType;
  * more user-friendly for programmers. The basic workflow for code generation
  * from C++ is as follows:
  *
- *    1. Create a CodeGenerator object to manage the actual compilation and
+ *    1. Create a CodeGenUtils object to manage the actual compilation and
  *       execution.
  *    2. Create a ClangCompiler object to act as front-end for compiling C++
- *       source code for use with the CodeGenerator.
+ *       source code for use with the CodeGenUtils.
  *    3. Build up C++ source code from in-memory strings as an llvm::Twine
  *       (llvm's Twine class is a string-like data type that allows for
  *       efficient concatenation). Note that any generated functions that we
@@ -55,13 +55,13 @@ struct AnnotatedType;
  *       and can be refered to by an ordinary non-mangled name when they are
  *       compiled.
  *    4. Call ClangCompiler::CompileCppSource() to compile C++ source code into
- *       an llvm Module managed by the CodeGenerator.
- *    5. Call CodeGenerator::Optimize() and CodeGenerator::PrepareForExecution()
+ *       an llvm Module managed by the CodeGenUtils.
+ *    5. Call CodeGenUtils::Optimize() and CodeGenUtils::PrepareForExecution()
  *       to compile the code and get it ready to execute. Note that we would do
  *       the same thing to compile generated IR code, except that it makes sense
  *       to use higher levels of optimization when starting from C++ sources, as
  *       the initial output of the clang frontend is NOT well-optimized IR.
- *    6. Call CodeGenerator::GetFunctionPointer() to get a callable function
+ *    6. Call CodeGenUtils::GetFunctionPointer() to get a callable function
  *       pointer to any desired generated function.
  **/
 class ClangCompiler {
@@ -69,23 +69,23 @@ class ClangCompiler {
   /**
    * @brief Constructor.
    *
-   * @param code_generator The CodeGenerator instance to compile with. The
-   *        specified CodeGenerator's LLVMContext will be used, and all
+   * @param codegen_utils The CodeGenUtils instance to compile with. The
+   *        specified CodeGenUtils's LLVMContext will be used, and all
    *        successfully-compiled modules will be inserted into the
-   *        CodeGenerator.
+   *        CodeGenUtils.
    **/
-  explicit ClangCompiler(CodeGenerator* code_generator)
-      : code_generator_(code_generator) {
+  explicit ClangCompiler(CodeGenUtils* codegen_utils)
+      : code_generator_(codegen_utils) {
   }
 
   /**
    * @brief Compile a C++ source-code snippet (i.e. an in-memory translation
-   *        unit) to an LLVM IR Module and place it in the CodeGenerator.
+   *        unit) to an LLVM IR Module and place it in the CodeGenUtils.
    *
    * @note It is recommended to mark any function you wish to call from outside
    *       of generated code as extern "C" so that its name will not be mangled
    *       and you can easily retrieve it by name from
-   *       CodeGenerator::GetFunctionPointer().
+   *       CodeGenUtils::GetFunctionPointer().
    *
    * @param source_code The C++ source code to compile.
    * @param debug If true, generate additional debugging information and dump
@@ -115,7 +115,7 @@ class ClangCompiler {
    *       becomes a pointer, otherwise the distinction is preserved).
    *
    * @param annotated_type An AnnotatedType created by
-   *        CodeGenerator::GetAnnotatedType().
+   *        CodeGenUtils::GetAnnotatedType().
    * @return The equivalent of annotated_type as a C++ type (in string form).
    **/
   static std::string CppTypeFromAnnotatedType(
@@ -123,17 +123,17 @@ class ClangCompiler {
 
   /**
    * @brief Generate forward-declarations for the named external functions
-   *        registered in the CodeGenerator that this ClangCompiler is attached
+   *        registered in the CodeGenUtils that this ClangCompiler is attached
    *        to.
    *
    * This allows (named) external functions registered with
-   * CodeGenerator::RegisterExternalFunction() to be called from generated C++
+   * CodeGenUtils::RegisterExternalFunction() to be called from generated C++
    * code. The string returned by this method can be concatenated with other
    * C++ source code that calls the external function(s) and passed to
    * CompileCppSource() for compilation.
    *
    * @return A C++ source snippet with forward declarations (marked extern "C")
-   *         for each named external function registered in the CodeGenerator.
+   *         for each named external function registered in the CodeGenUtils.
    **/
   std::string GenerateExternalFunctionDeclarations() const;
 
@@ -154,7 +154,7 @@ class ClangCompiler {
   std::string GetLiteralConstant(const CppType constant_value);
 
  private:
-  CodeGenerator* code_generator_;
+  CodeGenUtils* code_generator_;
 
   DISALLOW_COPY_AND_ASSIGN(ClangCompiler);
 };
@@ -175,7 +175,7 @@ std::string HexDouble(const double value);
 
 // ConstantPrinter has template specializations to handle different categories
 // of C++ types. Specializations provide a static Print() method that takes a
-// const CppType 'value' and a CodeGenerator* pointer (referring to the
+// const CppType 'value' and a CodeGenUtils* pointer (referring to the
 // 'code_generator_' member of the calling ClangCompiler) and returns a string
 // containing a C++ source snippet that parses to the original literal 'value'.
 template <typename CppType, typename Enable = void>
@@ -186,7 +186,7 @@ class ConstantPrinter {
 template <>
 class ConstantPrinter<bool> {
  public:
-  static std::string Print(const bool value, CodeGenerator* code_generator) {
+  static std::string Print(const bool value, CodeGenUtils* codegen_utils) {
     return value ? "true" : "false";
   }
 };
@@ -197,12 +197,12 @@ class ConstantPrinter<
     IntType,
     typename std::enable_if<std::is_integral<IntType>::value>::type> {
  public:
-  static std::string Print(const IntType value, CodeGenerator* code_generator) {
+  static std::string Print(const IntType value, CodeGenUtils* codegen_utils) {
     // Enclose the literal in a static_cast that transforms it to the exact type
     // expected.
     std::string literal("static_cast<");
     literal.append(ClangCompiler::CppTypeFromAnnotatedType(
-        code_generator->template GetAnnotatedType<IntType>()));
+        codegen_utils->template GetAnnotatedType<IntType>()));
     literal.append(">(");
 
     literal.append(std::to_string(value));
@@ -231,7 +231,7 @@ class ConstantPrinter<
 template <>
 class ConstantPrinter<float> {
  public:
-  static std::string Print(const float value, CodeGenerator* code_generator) {
+  static std::string Print(const float value, CodeGenUtils* codegen_utils) {
     // Get an unambiguously-rounded representation of the literal, then append
     // an "f" to denote that the literal is a 32-bit float instead of a 64-bit
     // double.
@@ -245,7 +245,7 @@ class ConstantPrinter<float> {
 template <>
 class ConstantPrinter<double> {
  public:
-  static std::string Print(const double value, CodeGenerator* code_generator) {
+  static std::string Print(const double value, CodeGenUtils* codegen_utils) {
     return HexDouble(value);
   }
 };
@@ -258,11 +258,11 @@ class ConstantPrinter<
     typename std::enable_if<std::is_enum<EnumType>::value>::type> {
  public:
   static std::string Print(const EnumType value,
-                           CodeGenerator* code_generator) {
+                           CodeGenUtils* codegen_utils) {
     return ConstantPrinter<typename std::underlying_type<EnumType>::type>
         ::Print(static_cast<typename std::underlying_type<EnumType>::type>(
                     value),
-                code_generator);
+                codegen_utils);
   }
 };
 
@@ -271,18 +271,18 @@ template <typename PointedType>
 class ConstantPrinter<PointedType*> {
  public:
   static std::string Print(PointedType* const value,
-                           CodeGenerator* code_generator) {
+                           CodeGenUtils* codegen_utils) {
     if (value == nullptr) {
       std::string literal("static_cast<");
       literal.append(ClangCompiler::CppTypeFromAnnotatedType(
-          code_generator->template GetAnnotatedType<PointedType*>()));
+          codegen_utils->template GetAnnotatedType<PointedType*>()));
       literal.append(">(nullptr)");
       return literal;
     } else {
       // Cast the literal address to the appropriate pointer type.
       std::string literal("reinterpret_cast<");
       literal.append(ClangCompiler::CppTypeFromAnnotatedType(
-          code_generator->template GetAnnotatedType<PointedType*>()));
+          codegen_utils->template GetAnnotatedType<PointedType*>()));
       literal.append(">(");
 
       // Write the literal address in integer form.
@@ -298,7 +298,7 @@ template <>
 class ConstantPrinter<std::nullptr_t> {
  public:
   static std::string Print(std::nullptr_t value,
-                           CodeGenerator* code_generator) {
+                           CodeGenUtils* codegen_utils) {
     return "nullptr";
   }
 };

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -3,7 +3,7 @@
 //  Copyright 2016 Pivotal Software, Inc.
 //
 //  @filename:
-//    code_generator.h
+//    codegen_utils.h
 //
 //  @doc:
 //    Object that manages runtime code generation for a single LLVM module.
@@ -13,8 +13,8 @@
 //
 //---------------------------------------------------------------------------
 
-#ifndef GPCODEGEN_CODE_GENERATOR_H_
-#define GPCODEGEN_CODE_GENERATOR_H_
+#ifndef GPCODEGEN_CODEGEN_UTILS_H_
+#define GPCODEGEN_CODEGEN_UTILS_H_
 
 #include <cassert>
 #include <cstddef>
@@ -45,9 +45,9 @@
 namespace gpcodegen {
 
 // Forward declaration of helper class for friending purposes.
-namespace code_generator_detail {
+namespace codegen_utils_detail {
 template <typename, typename> class ConstantMaker;
-}  // namespace code_generator_detail
+}  // namespace codegen_utils_detail
 
 /** \addtogroup codegen
  *  @{
@@ -56,7 +56,7 @@ template <typename, typename> class ConstantMaker;
 /**
  * @brief Object that manages runtime code generation for a single LLVM module.
  **/
-class CodeGenerator {
+class CodeGenUtils {
  public:
   enum class OptimizationLevel : unsigned {
     kNone = 0,   // -O0
@@ -75,17 +75,17 @@ class CodeGenerator {
    * @brief Constructor.
    *
    * @param module_name A human-readable name for the module that this
-   *        CodeGenerator will manage.
+   *        CodeGenUtils will manage.
    **/
-  explicit CodeGenerator(llvm::StringRef module_name);
+  explicit CodeGenUtils(llvm::StringRef module_name);
 
-  ~CodeGenerator() {
+  ~CodeGenUtils() {
   }
 
   /**
    * @brief Initialize global LLVM state (in particular, information about the
    *        host machine which will be the target for code generation). Must be
-   *        called at least once before creating CodeGenerator objects.
+   *        called at least once before creating CodeGenUtils objects.
    *
    * @return true if initilization was successful, false if some part of
    *         initialization failed.
@@ -100,10 +100,10 @@ class CodeGenerator {
   }
 
   /**
-   * @return The LLVM Module that is managed by this CodeGenerator, or NULL if
+   * @return The LLVM Module that is managed by this CodeGenUtils, or NULL if
    *         PrepareForExecution() has already been called.
    *
-   * @note When a CodeGenerator is initially created, a Module is created with
+   * @note When a CodeGenUtils is initially created, a Module is created with
    *       it and it is accessible via this method. The Module is mutable and
    *       new code can be inserted into it UNTIL PrepareForExecution() is
    *       called, at which point the Module's code is "frozen" and can no
@@ -135,7 +135,7 @@ class CodeGenerator {
    *
    * @tparam CppType a C++ type to map to an LLVM type.
    * @return A pointer to CppType's equivalent LLVM type in this
-   *         CodeGenerator's context.
+   *         CodeGenUtils's context.
    **/
   template <typename CppType>
   llvm::Type* GetType();
@@ -162,7 +162,7 @@ class CodeGenerator {
    * @tparam ReturnType The function's return type.
    * @tparam ArgumentTypes The types of any number of arguments to the function.
    * @return A pointer to the complete function type-signature's equivalent as
-   *         an LLVM FunctionType in this CodeGenerator's context.
+   *         an LLVM FunctionType in this CodeGenUtils's context.
    **/
   template <typename ReturnType, typename... ArgumentTypes>
   llvm::FunctionType* GetFunctionType();
@@ -179,7 +179,7 @@ class CodeGenerator {
    *
    * @param constant_value A C++ value to map to an LLVM constant.
    * @return A pointer to an llvm::Constant object with constant_value's value
-   *         in this CodeGenerator's context.
+   *         in this CodeGenUtils's context.
    **/
   template <typename CppType>
   llvm::Constant* GetConstant(const CppType constant_value);
@@ -221,7 +221,7 @@ class CodeGenerator {
 
   /**
    * @brief Create an LLVM function in the module managed by this
-   *        CodeGenerator.
+   *        CodeGenUtils.
    *
    * @note This method creates an empty Function object with no body. Caller
    *       can then create BasicBlocks inside the Function to implement its
@@ -235,7 +235,7 @@ class CodeGenerator {
    *        ExternalLinkage, which makes the function visible and callable from
    *        anywhere.
    * @return A pointer to a newly-created empty function in this
-   *         CodeGenerator's module (object is owned by this CodeGenerator).
+   *         CodeGenUtils's module (object is owned by this CodeGenUtils).
    **/
   template <typename ReturnType, typename... ArgumentTypes>
   llvm::Function* CreateFunction(
@@ -250,7 +250,7 @@ class CodeGenerator {
   }
 
   /**
-   * @brief Create a new BasicBlock inside a Function in this CodeGenerator's
+   * @brief Create a new BasicBlock inside a Function in this CodeGenUtils's
    *        module.
    *
    * @param name The name of the BasicBlock. This is not required to be unique,
@@ -294,9 +294,9 @@ class CodeGenerator {
    *         These do not need to be specified if external_function is not
    *         overloaded (they will be inferred automatically).
    * @param external_function A function pointer to install for use in this
-   *        CodeGenerator.
+   *        CodeGenUtils.
    * @param name An optional name to refer to the external function by. If
-   *        non-empty, this CodeGenerator will record additional information
+   *        non-empty, this CodeGenUtils will record additional information
    *        so that the registered function will also be callable by its name
    *        in C++ source code compiled by ClangCompiler (see
    *        ClangCompiler::GenerateExternalFunctionDeclarations()).
@@ -320,7 +320,7 @@ class CodeGenerator {
   }
 
   /**
-   * @brief Optimize the code in the module managed by this CodeGenerator before
+   * @brief Optimize the code in the module managed by this CodeGenUtils before
    *        execution.
    *
    * This method applies "generic" IR-to-IR optimization passes and is intended
@@ -349,7 +349,7 @@ class CodeGenerator {
                 const bool optimize_for_host_cpu);
 
   /**
-   * @brief Prepare code generated by this CodeGenerator for execution.
+   * @brief Prepare code generated by this CodeGenUtils for execution.
    *
    * Internally, this creates an LLVM MCJIT ExecutionEngine and gives ownership
    * of the Module to it. Actual compilation of functions may be deferred until
@@ -372,7 +372,7 @@ class CodeGenerator {
 
   /**
    * @brief Get a pointer to the compiled machine-code version of a function
-   *        generated by this CodeGenerator.
+   *        generated by this CodeGenUtils.
    *
    * @note PrepareForExecution() should be called before calling this method.
    *
@@ -404,7 +404,7 @@ class CodeGenerator {
   friend class ClangCompiler;
 
   template <typename, typename>
-  friend class code_generator_detail::ConstantMaker;
+  friend class codegen_utils_detail::ConstantMaker;
 
   // Allow ClangCompilerTest to inspect 'auxiliary_modules_' to check if they
   // have debugging information attached.
@@ -471,7 +471,7 @@ class CodeGenerator {
   llvm::LLVMContext context_;
   llvm::IRBuilder<> ir_builder_;
 
-  // Primary module directly managed by this CodeGenerator.
+  // Primary module directly managed by this CodeGenUtils.
   std::unique_ptr<llvm::Module> module_;
 
   // Additional modules to codegen from, generated by tools like ClangCompiler.
@@ -495,26 +495,27 @@ class CodeGenerator {
   std::vector<std::pair<const std::string, const std::uint64_t>>
       external_global_variables_;
 
-  // Counters for external variables/functions registered in this CodeGenerator.
+  // Counters for external variables/functions registered in this CodeGenUtils.
   // Used by GenerateExternalVariableName() and GenerateExternalFunctionName(),
   // respectively, to generate unique names for functions/globals.
   unsigned external_variable_counter_;
   unsigned external_function_counter_;
 
-  DISALLOW_COPY_AND_ASSIGN(CodeGenerator);
+  DISALLOW_COPY_AND_ASSIGN(CodeGenUtils);
 };
+
 
 /** @} */
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenerator::GetType() and
-// CodeGenerator::GetAnnotatedType().
+// Implementation of CodeGenUtils::GetType() and
+// CodeGenUtils::GetAnnotatedType().
 
 // Because function template partial specialization is not allowed, we use
 // helper classes to implement GetType() and GetAnnotatedType(). They are
 // encapsulated in this nested namespace, which is not considered part of the
 // public API.
-namespace code_generator_detail {
+namespace codegen_utils_detail {
 
 // type_traits-style template that detects whether 'T' is bool, or a const
 // and/or volatile qualified version of bool.
@@ -708,28 +709,28 @@ class TypeMaker<ReferentType&> {
   }
 };
 
-}  // namespace code_generator_detail
+}  // namespace codegen_utils_detail
 
 template <typename CppType>
-llvm::Type* CodeGenerator::GetType() {
-  return code_generator_detail::TypeMaker<CppType>::Get(&context_);
+llvm::Type* CodeGenUtils::GetType() {
+  return codegen_utils_detail::TypeMaker<CppType>::Get(&context_);
 }
 
 template <typename CppType>
-AnnotatedType CodeGenerator::GetAnnotatedType() {
-  return code_generator_detail::TypeMaker<CppType>::GetAnnotated(&context_);
+AnnotatedType CodeGenUtils::GetAnnotatedType() {
+  return codegen_utils_detail::TypeMaker<CppType>::GetAnnotated(&context_);
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenerator::GetFunctionType().
+// Implementation of CodeGenUtils::GetFunctionType().
 
 // Helper template classes are nested in this namespace and are not considered
 // part of the public API.
-namespace code_generator_detail {
+namespace codegen_utils_detail {
 
 // TypeVectorBuilder is a variadic template. Specializations of
 // TypeVectorBuilder have a two static methods AppendTypes() and
-// AppendAnnotatedTypes(). AppendTypes() takes a 'CodeGenerator*' pointer and a
+// AppendAnnotatedTypes(). AppendTypes() takes a 'CodeGenUtils*' pointer and a
 // pointer to a vector of 'llvm::Type*' pointers.
 // Calling TypeVectorBuilder<ArgumentTypes...>::AppendTypes() appends the
 // equivalent llvm::Type for each of 'ArgumentTypes' to the vector. Similarly,
@@ -742,12 +743,12 @@ class TypeVectorBuilder;
 template <>
 class TypeVectorBuilder<> {
  public:
-  static void AppendTypes(CodeGenerator* generator,
+  static void AppendTypes(CodeGenUtils* generator,
                           std::vector<llvm::Type*>* types) {
   }
 
   static void AppendAnnotatedTypes(
-      CodeGenerator* generator,
+      CodeGenUtils* generator,
       std::vector<AnnotatedType>* annotated_types) {
   }
 };
@@ -759,16 +760,16 @@ class TypeVectorBuilder<HeadType, TailTypes...> {
  public:
   static_assert(!std::is_same<HeadType, void>::value,
                 "void is not allowed as an argument type for "
-                "gpcodegen::CodeGenerator::GetFunctionType()");
+                "gpcodegen::CodeGenUtils::GetFunctionType()");
 
-  static void AppendTypes(CodeGenerator* generator,
+  static void AppendTypes(CodeGenUtils* generator,
                           std::vector<llvm::Type*>* types) {
     types->push_back(generator->GetType<HeadType>());
     TypeVectorBuilder<TailTypes...>::AppendTypes(generator, types);
   }
 
   static void AppendAnnotatedTypes(
-      CodeGenerator* generator,
+      CodeGenUtils* generator,
       std::vector<AnnotatedType>* annotated_types) {
     annotated_types->emplace_back(generator->GetAnnotatedType<HeadType>());
     TypeVectorBuilder<TailTypes...>::AppendAnnotatedTypes(generator,
@@ -776,29 +777,29 @@ class TypeVectorBuilder<HeadType, TailTypes...> {
   }
 };
 
-}  // namespace code_generator_detail
+}  // namespace codegen_utils_detail
 
 template <typename ReturnType, typename... ArgumentTypes>
-llvm::FunctionType* CodeGenerator::GetFunctionType() {
+llvm::FunctionType* CodeGenUtils::GetFunctionType() {
   std::vector<llvm::Type*> argument_types;
-  code_generator_detail::TypeVectorBuilder<ArgumentTypes...>::AppendTypes(
+  codegen_utils_detail::TypeVectorBuilder<ArgumentTypes...>::AppendTypes(
       this,
       &argument_types);
   return llvm::FunctionType::get(GetType<ReturnType>(), argument_types, false);
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenerator::GetConstant().
+// Implementation of CodeGenUtils::GetConstant().
 
 // Helper template classes are nested in this namespace and are not considered
 // part of the public API.
-namespace code_generator_detail {
+namespace codegen_utils_detail {
 
 // ConstantMaker has various template specializations to handle constants of
 // different C++ types. The specialized versions have a static method Get()
 // that takes a 'constant_value' of type 'const CppType' and a pointer to
-// a CodeGenerator object, and returns a pointer to an llvm::Constant
-// equivalent to 'constant_value' in the CodeGenerator's context.
+// a CodeGenUtils object, and returns a pointer to an llvm::Constant
+// equivalent to 'constant_value' in the CodeGenUtils's context.
 template <typename CppType, typename Enable = void>
 class ConstantMaker {
 };
@@ -815,7 +816,7 @@ class ConstantMaker<
                 "Unable to make an integer constant wider than 64 bits.");
 
   static llvm::Constant* Get(const UnsignedIntType constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     return llvm::ConstantInt::get(generator->GetType<UnsignedIntType>(),
                                   constant_value);
   }
@@ -833,7 +834,7 @@ class ConstantMaker<
                 "Unable to make an integer constant wider than 64 bits.");
 
   static llvm::Constant* Get(const SignedIntType constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     return llvm::ConstantInt::getSigned(generator->GetType<SignedIntType>(),
                                         constant_value);
   }
@@ -846,7 +847,7 @@ class ConstantMaker<
     typename std::enable_if<std::is_enum<EnumType>::value>::type> {
  public:
   static llvm::Constant* Get(const EnumType constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     typedef typename std::underlying_type<EnumType>::type EnumAsIntType;
     return ConstantMaker<EnumAsIntType>::Get(
         static_cast<EnumAsIntType>(constant_value),
@@ -859,7 +860,7 @@ template <>
 class ConstantMaker<float> {
  public:
   static llvm::Constant* Get(const float constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     return llvm::ConstantFP::get(generator->GetType<float>(),
                                  constant_value);
   }
@@ -870,7 +871,7 @@ template <>
 class ConstantMaker<double> {
  public:
   static llvm::Constant* Get(const double constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     return llvm::ConstantFP::get(generator->GetType<double>(),
                                  constant_value);
   }
@@ -881,7 +882,7 @@ template <typename PointedType>
 class ConstantMaker<PointedType*> {
  public:
   static llvm::Constant* Get(const PointedType* constant_value,
-                             CodeGenerator* generator) {
+                             CodeGenUtils* generator) {
     if (constant_value == nullptr) {
       return llvm::ConstantPointerNull::get(
           static_cast<llvm::PointerType*>(generator->GetType<PointedType*>()));
@@ -895,22 +896,22 @@ class ConstantMaker<PointedType*> {
   }
 };
 
-}  // namespace code_generator_detail
+}  // namespace codegen_utils_detail
 
 template <typename CppType>
-llvm::Constant* CodeGenerator::GetConstant(const CppType constant_value) {
-  return code_generator_detail::ConstantMaker<CppType>::Get(constant_value,
+llvm::Constant* CodeGenUtils::GetConstant(const CppType constant_value) {
+  return codegen_utils_detail::ConstantMaker<CppType>::Get(constant_value,
                                                             this);
 }
 
 // ----------------------------------------------------------------------------
 // Implementation of recursive variadic version of
-// CodeGenerator::GetPointerToMemberImpl().
+// CodeGenUtils::GetPointerToMemberImpl().
 
 template <typename StructType,
           typename MemberType,
           typename... TailPointerToMemberTypes>
-llvm::Value* CodeGenerator::GetPointerToMemberImpl(
+llvm::Value* CodeGenUtils::GetPointerToMemberImpl(
     llvm::Value* base_ptr,
     llvm::Type* cast_type,
     const std::size_t cumulative_offset,
@@ -940,14 +941,14 @@ llvm::Value* CodeGenerator::GetPointerToMemberImpl(
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenerator::RecordNamedExternalFunction()
+// Implementation of CodeGenUtils::RecordNamedExternalFunction()
 
 template <typename ReturnType, typename... ArgumentTypes>
-void CodeGenerator::RecordNamedExternalFunction(const std::string& name) {
+void CodeGenUtils::RecordNamedExternalFunction(const std::string& name) {
   NamedExternalFunction named_external_fn{name,
                                           GetAnnotatedType<ReturnType>(),
                                           {}};
-  code_generator_detail::TypeVectorBuilder<ArgumentTypes...>
+  codegen_utils_detail::TypeVectorBuilder<ArgumentTypes...>
       ::AppendAnnotatedTypes(this,
                              &named_external_fn.argument_types);
 
@@ -956,5 +957,5 @@ void CodeGenerator::RecordNamedExternalFunction(const std::string& name) {
 
 }  // namespace gpcodegen
 
-#endif  // GPCODEGEN_CODE_GENERATOR_H_
+#endif  // GPCODEGEN_CODEGEN_UTILS_H_
 // EOF

--- a/src/backend/codegen/include/codegen/utils/codegen_utils.h
+++ b/src/backend/codegen/include/codegen/utils/codegen_utils.h
@@ -56,7 +56,7 @@ template <typename, typename> class ConstantMaker;
 /**
  * @brief Object that manages runtime code generation for a single LLVM module.
  **/
-class CodeGenUtils {
+class CodegenUtils {
  public:
   enum class OptimizationLevel : unsigned {
     kNone = 0,   // -O0
@@ -75,17 +75,17 @@ class CodeGenUtils {
    * @brief Constructor.
    *
    * @param module_name A human-readable name for the module that this
-   *        CodeGenUtils will manage.
+   *        CodegenUtils will manage.
    **/
-  explicit CodeGenUtils(llvm::StringRef module_name);
+  explicit CodegenUtils(llvm::StringRef module_name);
 
-  ~CodeGenUtils() {
+  ~CodegenUtils() {
   }
 
   /**
    * @brief Initialize global LLVM state (in particular, information about the
    *        host machine which will be the target for code generation). Must be
-   *        called at least once before creating CodeGenUtils objects.
+   *        called at least once before creating CodegenUtils objects.
    *
    * @return true if initilization was successful, false if some part of
    *         initialization failed.
@@ -100,10 +100,10 @@ class CodeGenUtils {
   }
 
   /**
-   * @return The LLVM Module that is managed by this CodeGenUtils, or NULL if
+   * @return The LLVM Module that is managed by this CodegenUtils, or NULL if
    *         PrepareForExecution() has already been called.
    *
-   * @note When a CodeGenUtils is initially created, a Module is created with
+   * @note When a CodegenUtils is initially created, a Module is created with
    *       it and it is accessible via this method. The Module is mutable and
    *       new code can be inserted into it UNTIL PrepareForExecution() is
    *       called, at which point the Module's code is "frozen" and can no
@@ -135,7 +135,7 @@ class CodeGenUtils {
    *
    * @tparam CppType a C++ type to map to an LLVM type.
    * @return A pointer to CppType's equivalent LLVM type in this
-   *         CodeGenUtils's context.
+   *         CodegenUtils's context.
    **/
   template <typename CppType>
   llvm::Type* GetType();
@@ -162,7 +162,7 @@ class CodeGenUtils {
    * @tparam ReturnType The function's return type.
    * @tparam ArgumentTypes The types of any number of arguments to the function.
    * @return A pointer to the complete function type-signature's equivalent as
-   *         an LLVM FunctionType in this CodeGenUtils's context.
+   *         an LLVM FunctionType in this CodegenUtils's context.
    **/
   template <typename ReturnType, typename... ArgumentTypes>
   llvm::FunctionType* GetFunctionType();
@@ -179,7 +179,7 @@ class CodeGenUtils {
    *
    * @param constant_value A C++ value to map to an LLVM constant.
    * @return A pointer to an llvm::Constant object with constant_value's value
-   *         in this CodeGenUtils's context.
+   *         in this CodegenUtils's context.
    **/
   template <typename CppType>
   llvm::Constant* GetConstant(const CppType constant_value);
@@ -221,7 +221,7 @@ class CodeGenUtils {
 
   /**
    * @brief Create an LLVM function in the module managed by this
-   *        CodeGenUtils.
+   *        CodegenUtils.
    *
    * @note This method creates an empty Function object with no body. Caller
    *       can then create BasicBlocks inside the Function to implement its
@@ -235,7 +235,7 @@ class CodeGenUtils {
    *        ExternalLinkage, which makes the function visible and callable from
    *        anywhere.
    * @return A pointer to a newly-created empty function in this
-   *         CodeGenUtils's module (object is owned by this CodeGenUtils).
+   *         CodegenUtils's module (object is owned by this CodegenUtils).
    **/
   template <typename ReturnType, typename... ArgumentTypes>
   llvm::Function* CreateFunction(
@@ -250,7 +250,7 @@ class CodeGenUtils {
   }
 
   /**
-   * @brief Create a new BasicBlock inside a Function in this CodeGenUtils's
+   * @brief Create a new BasicBlock inside a Function in this CodegenUtils's
    *        module.
    *
    * @param name The name of the BasicBlock. This is not required to be unique,
@@ -294,9 +294,9 @@ class CodeGenUtils {
    *         These do not need to be specified if external_function is not
    *         overloaded (they will be inferred automatically).
    * @param external_function A function pointer to install for use in this
-   *        CodeGenUtils.
+   *        CodegenUtils.
    * @param name An optional name to refer to the external function by. If
-   *        non-empty, this CodeGenUtils will record additional information
+   *        non-empty, this CodegenUtils will record additional information
    *        so that the registered function will also be callable by its name
    *        in C++ source code compiled by ClangCompiler (see
    *        ClangCompiler::GenerateExternalFunctionDeclarations()).
@@ -320,7 +320,7 @@ class CodeGenUtils {
   }
 
   /**
-   * @brief Optimize the code in the module managed by this CodeGenUtils before
+   * @brief Optimize the code in the module managed by this CodegenUtils before
    *        execution.
    *
    * This method applies "generic" IR-to-IR optimization passes and is intended
@@ -349,7 +349,7 @@ class CodeGenUtils {
                 const bool optimize_for_host_cpu);
 
   /**
-   * @brief Prepare code generated by this CodeGenUtils for execution.
+   * @brief Prepare code generated by this CodegenUtils for execution.
    *
    * Internally, this creates an LLVM MCJIT ExecutionEngine and gives ownership
    * of the Module to it. Actual compilation of functions may be deferred until
@@ -372,7 +372,7 @@ class CodeGenUtils {
 
   /**
    * @brief Get a pointer to the compiled machine-code version of a function
-   *        generated by this CodeGenUtils.
+   *        generated by this CodegenUtils.
    *
    * @note PrepareForExecution() should be called before calling this method.
    *
@@ -471,7 +471,7 @@ class CodeGenUtils {
   llvm::LLVMContext context_;
   llvm::IRBuilder<> ir_builder_;
 
-  // Primary module directly managed by this CodeGenUtils.
+  // Primary module directly managed by this CodegenUtils.
   std::unique_ptr<llvm::Module> module_;
 
   // Additional modules to codegen from, generated by tools like ClangCompiler.
@@ -495,21 +495,21 @@ class CodeGenUtils {
   std::vector<std::pair<const std::string, const std::uint64_t>>
       external_global_variables_;
 
-  // Counters for external variables/functions registered in this CodeGenUtils.
+  // Counters for external variables/functions registered in this CodegenUtils.
   // Used by GenerateExternalVariableName() and GenerateExternalFunctionName(),
   // respectively, to generate unique names for functions/globals.
   unsigned external_variable_counter_;
   unsigned external_function_counter_;
 
-  DISALLOW_COPY_AND_ASSIGN(CodeGenUtils);
+  DISALLOW_COPY_AND_ASSIGN(CodegenUtils);
 };
 
 
 /** @} */
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenUtils::GetType() and
-// CodeGenUtils::GetAnnotatedType().
+// Implementation of CodegenUtils::GetType() and
+// CodegenUtils::GetAnnotatedType().
 
 // Because function template partial specialization is not allowed, we use
 // helper classes to implement GetType() and GetAnnotatedType(). They are
@@ -712,17 +712,17 @@ class TypeMaker<ReferentType&> {
 }  // namespace codegen_utils_detail
 
 template <typename CppType>
-llvm::Type* CodeGenUtils::GetType() {
+llvm::Type* CodegenUtils::GetType() {
   return codegen_utils_detail::TypeMaker<CppType>::Get(&context_);
 }
 
 template <typename CppType>
-AnnotatedType CodeGenUtils::GetAnnotatedType() {
+AnnotatedType CodegenUtils::GetAnnotatedType() {
   return codegen_utils_detail::TypeMaker<CppType>::GetAnnotated(&context_);
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenUtils::GetFunctionType().
+// Implementation of CodegenUtils::GetFunctionType().
 
 // Helper template classes are nested in this namespace and are not considered
 // part of the public API.
@@ -730,7 +730,7 @@ namespace codegen_utils_detail {
 
 // TypeVectorBuilder is a variadic template. Specializations of
 // TypeVectorBuilder have a two static methods AppendTypes() and
-// AppendAnnotatedTypes(). AppendTypes() takes a 'CodeGenUtils*' pointer and a
+// AppendAnnotatedTypes(). AppendTypes() takes a 'CodegenUtils*' pointer and a
 // pointer to a vector of 'llvm::Type*' pointers.
 // Calling TypeVectorBuilder<ArgumentTypes...>::AppendTypes() appends the
 // equivalent llvm::Type for each of 'ArgumentTypes' to the vector. Similarly,
@@ -743,12 +743,12 @@ class TypeVectorBuilder;
 template <>
 class TypeVectorBuilder<> {
  public:
-  static void AppendTypes(CodeGenUtils* generator,
+  static void AppendTypes(CodegenUtils* generator,
                           std::vector<llvm::Type*>* types) {
   }
 
   static void AppendAnnotatedTypes(
-      CodeGenUtils* generator,
+      CodegenUtils* generator,
       std::vector<AnnotatedType>* annotated_types) {
   }
 };
@@ -760,16 +760,16 @@ class TypeVectorBuilder<HeadType, TailTypes...> {
  public:
   static_assert(!std::is_same<HeadType, void>::value,
                 "void is not allowed as an argument type for "
-                "gpcodegen::CodeGenUtils::GetFunctionType()");
+                "gpcodegen::CodegenUtils::GetFunctionType()");
 
-  static void AppendTypes(CodeGenUtils* generator,
+  static void AppendTypes(CodegenUtils* generator,
                           std::vector<llvm::Type*>* types) {
     types->push_back(generator->GetType<HeadType>());
     TypeVectorBuilder<TailTypes...>::AppendTypes(generator, types);
   }
 
   static void AppendAnnotatedTypes(
-      CodeGenUtils* generator,
+      CodegenUtils* generator,
       std::vector<AnnotatedType>* annotated_types) {
     annotated_types->emplace_back(generator->GetAnnotatedType<HeadType>());
     TypeVectorBuilder<TailTypes...>::AppendAnnotatedTypes(generator,
@@ -780,7 +780,7 @@ class TypeVectorBuilder<HeadType, TailTypes...> {
 }  // namespace codegen_utils_detail
 
 template <typename ReturnType, typename... ArgumentTypes>
-llvm::FunctionType* CodeGenUtils::GetFunctionType() {
+llvm::FunctionType* CodegenUtils::GetFunctionType() {
   std::vector<llvm::Type*> argument_types;
   codegen_utils_detail::TypeVectorBuilder<ArgumentTypes...>::AppendTypes(
       this,
@@ -789,7 +789,7 @@ llvm::FunctionType* CodeGenUtils::GetFunctionType() {
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenUtils::GetConstant().
+// Implementation of CodegenUtils::GetConstant().
 
 // Helper template classes are nested in this namespace and are not considered
 // part of the public API.
@@ -798,8 +798,8 @@ namespace codegen_utils_detail {
 // ConstantMaker has various template specializations to handle constants of
 // different C++ types. The specialized versions have a static method Get()
 // that takes a 'constant_value' of type 'const CppType' and a pointer to
-// a CodeGenUtils object, and returns a pointer to an llvm::Constant
-// equivalent to 'constant_value' in the CodeGenUtils's context.
+// a CodegenUtils object, and returns a pointer to an llvm::Constant
+// equivalent to 'constant_value' in the CodegenUtils's context.
 template <typename CppType, typename Enable = void>
 class ConstantMaker {
 };
@@ -816,7 +816,7 @@ class ConstantMaker<
                 "Unable to make an integer constant wider than 64 bits.");
 
   static llvm::Constant* Get(const UnsignedIntType constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     return llvm::ConstantInt::get(generator->GetType<UnsignedIntType>(),
                                   constant_value);
   }
@@ -834,7 +834,7 @@ class ConstantMaker<
                 "Unable to make an integer constant wider than 64 bits.");
 
   static llvm::Constant* Get(const SignedIntType constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     return llvm::ConstantInt::getSigned(generator->GetType<SignedIntType>(),
                                         constant_value);
   }
@@ -847,7 +847,7 @@ class ConstantMaker<
     typename std::enable_if<std::is_enum<EnumType>::value>::type> {
  public:
   static llvm::Constant* Get(const EnumType constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     typedef typename std::underlying_type<EnumType>::type EnumAsIntType;
     return ConstantMaker<EnumAsIntType>::Get(
         static_cast<EnumAsIntType>(constant_value),
@@ -860,7 +860,7 @@ template <>
 class ConstantMaker<float> {
  public:
   static llvm::Constant* Get(const float constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     return llvm::ConstantFP::get(generator->GetType<float>(),
                                  constant_value);
   }
@@ -871,7 +871,7 @@ template <>
 class ConstantMaker<double> {
  public:
   static llvm::Constant* Get(const double constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     return llvm::ConstantFP::get(generator->GetType<double>(),
                                  constant_value);
   }
@@ -882,7 +882,7 @@ template <typename PointedType>
 class ConstantMaker<PointedType*> {
  public:
   static llvm::Constant* Get(const PointedType* constant_value,
-                             CodeGenUtils* generator) {
+                             CodegenUtils* generator) {
     if (constant_value == nullptr) {
       return llvm::ConstantPointerNull::get(
           static_cast<llvm::PointerType*>(generator->GetType<PointedType*>()));
@@ -899,19 +899,19 @@ class ConstantMaker<PointedType*> {
 }  // namespace codegen_utils_detail
 
 template <typename CppType>
-llvm::Constant* CodeGenUtils::GetConstant(const CppType constant_value) {
+llvm::Constant* CodegenUtils::GetConstant(const CppType constant_value) {
   return codegen_utils_detail::ConstantMaker<CppType>::Get(constant_value,
                                                             this);
 }
 
 // ----------------------------------------------------------------------------
 // Implementation of recursive variadic version of
-// CodeGenUtils::GetPointerToMemberImpl().
+// CodegenUtils::GetPointerToMemberImpl().
 
 template <typename StructType,
           typename MemberType,
           typename... TailPointerToMemberTypes>
-llvm::Value* CodeGenUtils::GetPointerToMemberImpl(
+llvm::Value* CodegenUtils::GetPointerToMemberImpl(
     llvm::Value* base_ptr,
     llvm::Type* cast_type,
     const std::size_t cumulative_offset,
@@ -941,10 +941,10 @@ llvm::Value* CodeGenUtils::GetPointerToMemberImpl(
 }
 
 // ----------------------------------------------------------------------------
-// Implementation of CodeGenUtils::RecordNamedExternalFunction()
+// Implementation of CodegenUtils::RecordNamedExternalFunction()
 
 template <typename ReturnType, typename... ArgumentTypes>
-void CodeGenUtils::RecordNamedExternalFunction(const std::string& name) {
+void CodegenUtils::RecordNamedExternalFunction(const std::string& name) {
   NamedExternalFunction named_external_fn{name,
                                           GetAnnotatedType<ReturnType>(),
                                           {}};

--- a/src/backend/codegen/include/codegen/utils/instance_method_wrappers.h
+++ b/src/backend/codegen/include/codegen/utils/instance_method_wrappers.h
@@ -221,7 +221,7 @@ ClassType* WrapPlacementNew(void* place, ArgumentTypes... args) {
  * @brief Templated wrapper function that invokes the 'new' operator with the
  *        move constructor for a class (if any) to move-from an existing object.
  *
- * @note This template works around the fact that CodeGenUtils does not handle
+ * @note This template works around the fact that CodegenUtils does not handle
  *       rvalue-references. It takes a pointer which it dereferences and
  *       converts to an rvalue-reference that is moved-from.
  *
@@ -240,7 +240,7 @@ ClassType* WrapNewMove(ClassType* original) {
  *        'new' operator with the move constructor for a class (if any) to
  *        move-from an existing object.
  *
- * @note This template works around the fact that CodeGenUtils does not handle
+ * @note This template works around the fact that CodegenUtils does not handle
  *       rvalue-references. It takes a pointer which it dereferences and
  *       converts to an rvalue-reference that is moved-from.
  * @warning All of the usual caveats about placement new also apply here, e.g.

--- a/src/backend/codegen/include/codegen/utils/instance_method_wrappers.h
+++ b/src/backend/codegen/include/codegen/utils/instance_method_wrappers.h
@@ -221,7 +221,7 @@ ClassType* WrapPlacementNew(void* place, ArgumentTypes... args) {
  * @brief Templated wrapper function that invokes the 'new' operator with the
  *        move constructor for a class (if any) to move-from an existing object.
  *
- * @note This template works around the fact that CodeGenerator does not handle
+ * @note This template works around the fact that CodeGenUtils does not handle
  *       rvalue-references. It takes a pointer which it dereferences and
  *       converts to an rvalue-reference that is moved-from.
  *
@@ -240,7 +240,7 @@ ClassType* WrapNewMove(ClassType* original) {
  *        'new' operator with the move constructor for a class (if any) to
  *        move-from an existing object.
  *
- * @note This template works around the fact that CodeGenerator does not handle
+ * @note This template works around the fact that CodeGenUtils does not handle
  *       rvalue-references. It takes a pointer which it dereferences and
  *       converts to an rvalue-reference that is moved-from.
  * @warning All of the usual caveats about placement new also apply here, e.g.

--- a/src/backend/codegen/include/codegen/utils/utility.h
+++ b/src/backend/codegen/include/codegen/utils/utility.h
@@ -17,6 +17,7 @@
 #define GPCODEGEN_UTILITY_H_
 
 #include "llvm/IR/Function.h"
+#include <utility>
 
 namespace gpcodegen {
 
@@ -32,7 +33,7 @@ namespace gpcodegen {
  * @return A pointer to the specified argument, or NULL if the specified
  *         position was beyond the end of function's arguments.
  **/
-llvm::Argument* ArgumentByPosition(llvm::Function* function,
+static llvm::Argument* ArgumentByPosition(llvm::Function* function,
                                    const unsigned position) {
   llvm::Function::arg_iterator it = function->arg_begin();
   if (it == function->arg_end()) {

--- a/src/backend/codegen/init_codegen.cc
+++ b/src/backend/codegen/init_codegen.cc
@@ -12,8 +12,8 @@
 
 #include "codegen/init_codegen.h"
 
-#include "codegen/utils/code_generator.h"
+#include "codegen/utils/codegen_utils.h"
 
 extern "C" int InitCodeGen() {
-  return gpcodegen::CodeGenerator::InitializeGlobal() ? 0 : 1;
+  return gpcodegen::CodeGenUtils::InitializeGlobal() ? 0 : 1;
 }

--- a/src/backend/codegen/init_codegen.cc
+++ b/src/backend/codegen/init_codegen.cc
@@ -14,6 +14,6 @@
 
 #include "codegen/utils/codegen_utils.h"
 
-extern "C" int InitCodeGen() {
-  return gpcodegen::CodeGenUtils::InitializeGlobal() ? 0 : 1;
+extern "C" int InitCodegen() {
+  return gpcodegen::CodegenUtils::InitializeGlobal() ? 0 : 1;
 }

--- a/src/backend/codegen/tests/clang_compiler_unittest.cc
+++ b/src/backend/codegen/tests/clang_compiler_unittest.cc
@@ -18,7 +18,8 @@
 #include <type_traits>
 
 #include "codegen/utils/clang_compiler.h"
-#include "codegen/utils/code_generator.h"
+
+#include "codegen/utils/codegen_utils.h"
 #include "codegen/utils/instance_method_wrappers.h"
 #include "gtest/gtest.h"
 #include "llvm/ADT/Twine.h"
@@ -52,35 +53,35 @@ enum class UInt16Enum : std::uint16_t {
 class ClangCompilerTestEnvironment : public ::testing::Environment {
  public:
   virtual void SetUp() {
-    ASSERT_TRUE(CodeGenerator::InitializeGlobal());
+    ASSERT_TRUE(CodeGenUtils::InitializeGlobal());
   }
 };
 
 class ClangCompilerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    code_generator_.reset(new CodeGenerator("test_module"));
-    clang_compiler_.reset(new ClangCompiler(code_generator_.get()));
+    codegen_utils_.reset(new CodeGenUtils("test_module"));
+    clang_compiler_.reset(new ClangCompiler(codegen_utils_.get()));
   }
 
-  // Check whether the auxiliary module specified by 'idx' in 'code_generator_'
+  // Check whether the auxiliary module specified by 'idx' in 'codegen_utils_'
   // has debugging metadata attached.
   bool AuxiliaryModuleHasDebugInfo(const std::size_t idx) {
     // The "compile unit" (i.e. translation unit) level debugging info emitted
     // by the clang frontend is called "llvm.dbg.cu".
-    return code_generator_->auxiliary_modules_.at(idx)->getNamedMetadata(
+    return codegen_utils_->auxiliary_modules_.at(idx)->getNamedMetadata(
                "llvm.dbg.cu")
            != nullptr;
   }
 
   // Helper method for CppTypeFromAnnotatedTypeTest. Checks that invoking
   // ClangCompiler::CppTypeFromAnnotatedType() on the AnnotatedType produced
-  // by CodeGenerator::GetType<T>() returns 'expected_cpp_type'.
+  // by CodeGenUtils::GetType<T>() returns 'expected_cpp_type'.
   template <typename T>
   void CheckCppTypeFromAnnotatedType(const std::string& expected_cpp_type) {
     EXPECT_EQ(expected_cpp_type,
               ClangCompiler::CppTypeFromAnnotatedType(
-                  code_generator_->GetAnnotatedType<T>()));
+                  codegen_utils_->GetAnnotatedType<T>()));
   }
 
   template <typename T>
@@ -90,7 +91,7 @@ class ClangCompilerTest : public ::testing::Test {
               clang_compiler_->GetLiteralConstant(original_value));
   }
 
-  std::unique_ptr<CodeGenerator> code_generator_;
+  std::unique_ptr<CodeGenUtils> codegen_utils_;
   std::unique_ptr<ClangCompiler> clang_compiler_;
 };
 
@@ -113,12 +114,12 @@ TEST_F(ClangCompilerTest, BasicCompilationTest) {
   EXPECT_TRUE(clang_compiler_->CompileCppSource(kBasicCompilationSource));
 
   // Now do actual codegen and try and call the function.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
-      = code_generator_->GetFunctionPointer<unsigned,
+      = codegen_utils_->GetFunctionPointer<unsigned,
                                             const unsigned,
                                             const unsigned>(
           "binomial_coefficient");
@@ -159,12 +160,12 @@ TEST_F(ClangCompilerTest, MultiModuleCompilationTest) {
       kMultiModuleBinomialCoeffecientSource));
 
   // Now do actual codegen and try and call the function.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
-      = code_generator_->GetFunctionPointer<unsigned,
+      = codegen_utils_->GetFunctionPointer<unsigned,
                                             const unsigned,
                                             const unsigned>(
           "binomial_coefficient");
@@ -375,17 +376,17 @@ static const char kExternalFunctionBinomialCoefficientSource[] =
 }  // namespace
 
 TEST_F(ClangCompilerTest, ExternalFunctionTest) {
-  code_generator_->RegisterExternalFunction(&factorial, "factorial");
+  codegen_utils_->RegisterExternalFunction(&factorial, "factorial");
   EXPECT_TRUE(clang_compiler_->CompileCppSource(
       llvm::Twine(clang_compiler_->GenerateExternalFunctionDeclarations())
           .concat(kExternalFunctionBinomialCoefficientSource)));
 
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
-      = code_generator_->GetFunctionPointer<unsigned,
+      = codegen_utils_->GetFunctionPointer<unsigned,
                                             const unsigned,
                                             const unsigned>(
           "binomial_coefficient");
@@ -434,16 +435,16 @@ static const char kExternalMethodInvocationSource[] =
 }  // namespace
 
 TEST_F(ClangCompilerTest, ExternalMethodTest) {
-  code_generator_->RegisterExternalFunction(
+  codegen_utils_->RegisterExternalFunction(
       &WrapNew<Accumulator<double>, double>,
       "new_Accumulator");
-  code_generator_->RegisterExternalFunction(
+  codegen_utils_->RegisterExternalFunction(
       &WrapDelete<Accumulator<double>>,
       "delete_Accumulator");
-  code_generator_->RegisterExternalFunction(
+  codegen_utils_->RegisterExternalFunction(
       &GPCODEGEN_WRAP_METHOD(&Accumulator<double>::Accumulate),
       "Accumulator_Accumulate");
-  code_generator_->RegisterExternalFunction(
+  codegen_utils_->RegisterExternalFunction(
       &GPCODEGEN_WRAP_METHOD(&Accumulator<double>::Get),
       "Accumulator_Get");
 
@@ -451,12 +452,12 @@ TEST_F(ClangCompilerTest, ExternalMethodTest) {
       llvm::Twine(clang_compiler_->GenerateExternalFunctionDeclarations())
           .concat(kExternalMethodInvocationSource)));
 
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       false));
 
   double (*AddWithAccumulator)(const double, const double, const double)
-      = code_generator_->GetFunctionPointer<double,
+      = codegen_utils_->GetFunctionPointer<double,
                                             const double,
                                             const double,
                                             const double>("AddWithAccumulator");

--- a/src/backend/codegen/tests/clang_compiler_unittest.cc
+++ b/src/backend/codegen/tests/clang_compiler_unittest.cc
@@ -53,14 +53,14 @@ enum class UInt16Enum : std::uint16_t {
 class ClangCompilerTestEnvironment : public ::testing::Environment {
  public:
   virtual void SetUp() {
-    ASSERT_TRUE(CodeGenUtils::InitializeGlobal());
+    ASSERT_TRUE(CodegenUtils::InitializeGlobal());
   }
 };
 
 class ClangCompilerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    codegen_utils_.reset(new CodeGenUtils("test_module"));
+    codegen_utils_.reset(new CodegenUtils("test_module"));
     clang_compiler_.reset(new ClangCompiler(codegen_utils_.get()));
   }
 
@@ -76,7 +76,7 @@ class ClangCompilerTest : public ::testing::Test {
 
   // Helper method for CppTypeFromAnnotatedTypeTest. Checks that invoking
   // ClangCompiler::CppTypeFromAnnotatedType() on the AnnotatedType produced
-  // by CodeGenUtils::GetType<T>() returns 'expected_cpp_type'.
+  // by CodegenUtils::GetType<T>() returns 'expected_cpp_type'.
   template <typename T>
   void CheckCppTypeFromAnnotatedType(const std::string& expected_cpp_type) {
     EXPECT_EQ(expected_cpp_type,
@@ -91,7 +91,7 @@ class ClangCompilerTest : public ::testing::Test {
               clang_compiler_->GetLiteralConstant(original_value));
   }
 
-  std::unique_ptr<CodeGenUtils> codegen_utils_;
+  std::unique_ptr<CodegenUtils> codegen_utils_;
   std::unique_ptr<ClangCompiler> clang_compiler_;
 };
 
@@ -115,7 +115,7 @@ TEST_F(ClangCompilerTest, BasicCompilationTest) {
 
   // Now do actual codegen and try and call the function.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
@@ -161,7 +161,7 @@ TEST_F(ClangCompilerTest, MultiModuleCompilationTest) {
 
   // Now do actual codegen and try and call the function.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
@@ -382,7 +382,7 @@ TEST_F(ClangCompilerTest, ExternalFunctionTest) {
           .concat(kExternalFunctionBinomialCoefficientSource)));
 
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       false));
 
   unsigned (*binomial_coefficient)(const unsigned, const unsigned)
@@ -453,7 +453,7 @@ TEST_F(ClangCompilerTest, ExternalMethodTest) {
           .concat(kExternalMethodInvocationSource)));
 
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       false));
 
   double (*AddWithAccumulator)(const double, const double, const double)

--- a/src/backend/codegen/tests/codegen_utils_unittest.cc
+++ b/src/backend/codegen/tests/codegen_utils_unittest.cc
@@ -6,7 +6,7 @@
 //    code_generator_unittest.cc
 //
 //  @doc:
-//    Unit tests for utils/code_generator.cc
+//    Unit tests for utils/codegen_utils.cc
 //
 //  @test:
 //
@@ -26,8 +26,8 @@
 #include <utility>
 #include <vector>
 
+#include "codegen/utils/codegen_utils.h"
 #include "codegen/utils/annotated_type.h"
-#include "codegen/utils/code_generator.h"
 #include "codegen/utils/instance_method_wrappers.h"
 #include "codegen/utils/utility.h"
 #include "gtest/gtest.h"
@@ -95,7 +95,7 @@ struct DummyStruct {
 };
 
 // A dummy struct with several char fields that map to LLVM's i8 type. Used to
-// check that CodeGenerator::GetPointerToMember() works correctly when the type
+// check that CodeGenUtils::GetPointerToMember() works correctly when the type
 // of a pointer to the field to be accessed is the same as the type used for
 // underlying pointer arithmetic.
 struct DummyStructWithCharFields {
@@ -238,31 +238,31 @@ struct ExpectLongLong<EnumT,
 
 // Test environment to handle global per-process initialization tasks for all
 // tests.
-class CodeGeneratorTestEnvironment : public ::testing::Environment {
+class CodeGenUtilsTestEnvironment : public ::testing::Environment {
  public:
   virtual void SetUp() {
-    ASSERT_TRUE(CodeGenerator::InitializeGlobal());
+    ASSERT_TRUE(CodeGenUtils::InitializeGlobal());
   }
 };
 
-class CodeGeneratorTest : public ::testing::Test {
+class CodeGenUtilsTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    code_generator_.reset(new CodeGenerator("test_module"));
+    codegen_utils_.reset(new CodeGenUtils("test_module"));
   }
 
-  // Helper method for GetScalarTypeTest. Tests CodeGenerator::GetType() and
-  // CodeGenerator::GetAnnotatedType() for an 'IntegerType' and its
+  // Helper method for GetScalarTypeTest. Tests CodeGenUtils::GetType() and
+  // CodeGenUtils::GetAnnotatedType() for an 'IntegerType' and its
   // const-qualified version.
   template <typename IntegerType>
   void CheckGetIntegerType() {
-    llvm::Type* llvm_type = code_generator_->GetType<IntegerType>();
+    llvm::Type* llvm_type = codegen_utils_->GetType<IntegerType>();
     ASSERT_NE(llvm_type, nullptr);
     EXPECT_TRUE(llvm_type->isIntegerTy(sizeof(IntegerType) << 3));
 
     // Check extra information from AnnotatedType.
     AnnotatedType annotated_type
-        = code_generator_->GetAnnotatedType<IntegerType>();
+        = codegen_utils_->GetAnnotatedType<IntegerType>();
     ASSERT_NE(annotated_type.llvm_type, nullptr);
     EXPECT_FALSE(annotated_type.is_voidptr);
     EXPECT_FALSE(annotated_type.is_reference);
@@ -276,11 +276,11 @@ class CodeGeneratorTest : public ::testing::Test {
     EXPECT_FALSE(annotated_type.is_volatile.front());
 
     // Also check with const-qualifier.
-    llvm_type = code_generator_->GetType<const IntegerType>();
+    llvm_type = codegen_utils_->GetType<const IntegerType>();
     ASSERT_NE(llvm_type, nullptr);
     EXPECT_TRUE(llvm_type->isIntegerTy(sizeof(IntegerType) << 3));
 
-    annotated_type = code_generator_->GetAnnotatedType<const IntegerType>();
+    annotated_type = codegen_utils_->GetAnnotatedType<const IntegerType>();
     ASSERT_NE(annotated_type.llvm_type, nullptr);
     EXPECT_FALSE(annotated_type.is_voidptr);
     EXPECT_FALSE(annotated_type.is_reference);
@@ -294,17 +294,17 @@ class CodeGeneratorTest : public ::testing::Test {
     EXPECT_FALSE(annotated_type.is_volatile.front());
   }
 
-  // Helper method for GetScalarTypeTest. Tests CodeGenerator::GetType() for an
+  // Helper method for GetScalarTypeTest. Tests CodeGenUtils::GetType() for an
   // 'EnumType' that is expected to map to 'EquivalentIntegerType'.
   template <typename EnumType, typename EquivalentIntegerType>
   void CheckGetEnumType() {
-    llvm::Type* llvm_type = code_generator_->GetType<EnumType>();
+    llvm::Type* llvm_type = codegen_utils_->GetType<EnumType>();
     ASSERT_NE(llvm_type, nullptr);
     EXPECT_TRUE(llvm_type->isIntegerTy(sizeof(EquivalentIntegerType) << 3));
 
     // Check extra information from AnnotatedType.
     AnnotatedType annotated_type
-        = code_generator_->GetAnnotatedType<EnumType>();
+        = codegen_utils_->GetAnnotatedType<EnumType>();
     ASSERT_NE(annotated_type.llvm_type, nullptr);
     EXPECT_FALSE(annotated_type.is_voidptr);
     EXPECT_FALSE(annotated_type.is_reference);
@@ -319,11 +319,11 @@ class CodeGeneratorTest : public ::testing::Test {
     EXPECT_FALSE(annotated_type.is_volatile.front());
 
     // Also check with const-qualifier.
-    llvm_type = code_generator_->GetType<const EnumType>();
+    llvm_type = codegen_utils_->GetType<const EnumType>();
     ASSERT_NE(llvm_type, nullptr);
     EXPECT_TRUE(llvm_type->isIntegerTy(sizeof(EquivalentIntegerType) << 3));
 
-    annotated_type = code_generator_->GetAnnotatedType<const EnumType>();
+    annotated_type = codegen_utils_->GetAnnotatedType<const EnumType>();
     ASSERT_NE(annotated_type.llvm_type, nullptr);
     EXPECT_FALSE(annotated_type.is_voidptr);
     EXPECT_FALSE(annotated_type.is_reference);
@@ -340,16 +340,16 @@ class CodeGeneratorTest : public ::testing::Test {
     // Check that the Type used for the enum is the exact same as the Type that
     // would be used for the underlying integer.
     llvm::Type* int_llvm_type
-        = code_generator_->GetType<EquivalentIntegerType>();
+        = codegen_utils_->GetType<EquivalentIntegerType>();
     EXPECT_EQ(llvm_type, int_llvm_type);
   }
 
   // Helper method for GetPointerTypeTest. Checks that the annotations produced
-  // by CodeGenerator::GetAnnotatedType() are as expected for a given
+  // by CodeGenUtils::GetAnnotatedType() are as expected for a given
   // 'PointerType' (which may also be a reference).
   //
   // NOTE(chasseur): This works with up to 2 levels of indirection (e.g. pointer
-  // to pointer) which is as far as we test. CodeGenerator::GetAnnotatedType()
+  // to pointer) which is as far as we test. CodeGenUtils::GetAnnotatedType()
   // should work for arbitrarily deep chains of pointers, but this check method
   // only looks at most 2 pointers deep.
   template <typename PointerType>
@@ -465,8 +465,8 @@ class CodeGeneratorTest : public ::testing::Test {
     }
   }
 
-  // Helper method for GetPointerTypeTest. Calls CodeGenerator::GetType() and
-  // CodeGenerator::GetAnnotatedType() for 4 versions of a pointer to
+  // Helper method for GetPointerTypeTest. Calls CodeGenUtils::GetType() and
+  // CodeGenUtils::GetAnnotatedType() for 4 versions of a pointer to
   // 'PointedType' with various const-qualifiers (regular mutable pointer,
   // pointer to const, const-pointer, and const-pointer to const) and invokes
   // 'check_functor' on the returned llvm::Type*. check_functor's call operator
@@ -478,27 +478,27 @@ class CodeGeneratorTest : public ::testing::Test {
   // type system are as expected for each checked pointer type.
   template <typename PointedType, typename CheckFunctor>
   void CheckAllPointerFlavors(const CheckFunctor& check_functor) {
-    check_functor(code_generator_->GetType<PointedType*>());
-    check_functor(code_generator_->GetType<const PointedType*>());
-    check_functor(code_generator_->GetType<PointedType* const>());
-    check_functor(code_generator_->GetType<const PointedType* const>());
+    check_functor(codegen_utils_->GetType<PointedType*>());
+    check_functor(codegen_utils_->GetType<const PointedType*>());
+    check_functor(codegen_utils_->GetType<PointedType* const>());
+    check_functor(codegen_utils_->GetType<const PointedType* const>());
 
     // Also check GetAnnotatedType().
     AnnotatedType annotated_type
-        = code_generator_->GetAnnotatedType<PointedType*>();
+        = codegen_utils_->GetAnnotatedType<PointedType*>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<PointedType*>(annotated_type);
 
-    annotated_type = code_generator_->GetAnnotatedType<const PointedType*>();
+    annotated_type = codegen_utils_->GetAnnotatedType<const PointedType*>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<const PointedType*>(annotated_type);
 
-    annotated_type = code_generator_->GetAnnotatedType<PointedType* const>();
+    annotated_type = codegen_utils_->GetAnnotatedType<PointedType* const>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<PointedType* const>(annotated_type);
 
     annotated_type
-        = code_generator_->GetAnnotatedType<const PointedType* const>();
+        = codegen_utils_->GetAnnotatedType<const PointedType* const>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<const PointedType* const>(annotated_type);
   }
@@ -510,16 +510,16 @@ class CodeGeneratorTest : public ::testing::Test {
   void CheckAllPointerAndReferenceFlavors(const CheckFunctor& check_functor) {
     CheckAllPointerFlavors<PointedType, CheckFunctor>(check_functor);
 
-    check_functor(code_generator_->GetType<PointedType&>());
-    check_functor(code_generator_->GetType<const PointedType&>());
+    check_functor(codegen_utils_->GetType<PointedType&>());
+    check_functor(codegen_utils_->GetType<const PointedType&>());
 
     // Also check GetAnnotatedType() for reference types.
     AnnotatedType annotated_type
-        = code_generator_->GetAnnotatedType<PointedType&>();
+        = codegen_utils_->GetAnnotatedType<PointedType&>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<PointedType&>(annotated_type);
 
-    annotated_type = code_generator_->GetAnnotatedType<const PointedType&>();
+    annotated_type = codegen_utils_->GetAnnotatedType<const PointedType&>();
     check_functor(annotated_type.llvm_type);
     CheckAnnotationsForPointer<const PointedType&>(annotated_type);
   }
@@ -553,7 +553,7 @@ class CodeGeneratorTest : public ::testing::Test {
           sizeof(EquivalentIntegerType) << 3));
 
       llvm::Type* int_llvm_type
-          = code_generator_->GetType<EquivalentIntegerType*>();
+          = codegen_utils_->GetType<EquivalentIntegerType*>();
       EXPECT_EQ(llvm_type, int_llvm_type);
     };
 
@@ -564,13 +564,13 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for a single 'integer_constant'.
+  // CodeGenUtils::GetConstant() for a single 'integer_constant'.
   template <typename IntegerType>
   void CheckGetSingleIntegerConstant(const IntegerType integer_constant) {
-    llvm::Constant* constant = code_generator_->GetConstant(integer_constant);
+    llvm::Constant* constant = codegen_utils_->GetConstant(integer_constant);
 
     // Check the type.
-    EXPECT_EQ(code_generator_->GetType<IntegerType>(), constant->getType());
+    EXPECT_EQ(codegen_utils_->GetType<IntegerType>(), constant->getType());
 
     // Check the value.
     const llvm::APInt& constant_apint = constant->getUniqueInteger();
@@ -588,7 +588,7 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for an 'IntegerType' with several values
+  // CodeGenUtils::GetConstant() for an 'IntegerType' with several values
   // of the specified integer type (0, 1, 123, the maximum, and if signed,
   // -1, -123, and the minimum).
   template <typename IntegerType>
@@ -607,14 +607,14 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for a single 'fp_constant'.
+  // CodeGenUtils::GetConstant() for a single 'fp_constant'.
   template <typename FloatingPointType>
   void CheckGetSingleFloatingPointConstant(
       const FloatingPointType fp_constant) {
-    llvm::Constant* constant = code_generator_->GetConstant(fp_constant);
+    llvm::Constant* constant = codegen_utils_->GetConstant(fp_constant);
 
     // Check the type.
-    EXPECT_EQ(code_generator_->GetType<FloatingPointType>(),
+    EXPECT_EQ(codegen_utils_->GetType<FloatingPointType>(),
               constant->getType());
 
     // Check the value.
@@ -635,7 +635,7 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for a 'FloatingPointType' with several values
+  // CodeGenUtils::GetConstant() for a 'FloatingPointType' with several values
   // of the specified floating point type (positive and negative zero, positive
   // and negative 12.34, the minimum and maximum possible normalized values,
   // the highest-magnitude negative value, the smallest possible nonzero
@@ -659,13 +659,13 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for a single 'enum_constant'.
+  // CodeGenUtils::GetConstant() for a single 'enum_constant'.
   template <typename EnumType>
   void CheckGetSingleEnumConstant(const EnumType enum_constant) {
-    llvm::Constant* constant = code_generator_->GetConstant(enum_constant);
+    llvm::Constant* constant = codegen_utils_->GetConstant(enum_constant);
 
     // Check the type.
-    EXPECT_EQ(code_generator_->GetType<EnumType>(), constant->getType());
+    EXPECT_EQ(codegen_utils_->GetType<EnumType>(), constant->getType());
 
     // Check the value (implicitly converted to the underlying integer type).
     const llvm::APInt& constant_apint = constant->getUniqueInteger();
@@ -689,7 +689,7 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenerator::GetConstant() for an 'EnumType' by calling
+  // CodeGenUtils::GetConstant() for an 'EnumType' by calling
   // CheckGetSingleEnumConstant() for each constant listed in 'enum_constants'.
   template <typename EnumType>
   void CheckGetEnumConstants(std::initializer_list<EnumType> enum_constants) {
@@ -721,18 +721,18 @@ class CodeGeneratorTest : public ::testing::Test {
       const std::vector<std::uintptr_t>& pointer_check_addresses) {
     for (std::size_t idx = 0; idx < pointer_check_addresses.size(); ++idx) {
       std::uintptr_t (*check_fn)()
-          = code_generator_->GetFunctionPointer<std::uintptr_t>(
+          = codegen_utils_->GetFunctionPointer<std::uintptr_t>(
               GlobalConstantAccessorName(idx));
       EXPECT_EQ(pointer_check_addresses[idx], (*check_fn)());
     }
   }
 
   // Helper method for GetPointerConstantTest. Tests
-  // CodeGenerator::GetConstant() for 'ptr_constant'. Verifies that the
+  // CodeGenUtils::GetConstant() for 'ptr_constant'. Verifies that the
   // pointer Constant returned is the expected type and generates an accessor
   // function that returns the address of the pointer constant, recording the
   // expected address in '*pointer_check_addresses'. After all of the
-  // invocations of this method in a test, CodeGenerator::PrepareForExecution()
+  // invocations of this method in a test, CodeGenUtils::PrepareForExecution()
   // should be called to compile the accessor functions, then
   // FinishCheckingGlobalConstantPointers() should be called to make sure that
   // the accessor functions return the expected addresses.
@@ -740,32 +740,32 @@ class CodeGeneratorTest : public ::testing::Test {
   void CheckGetSinglePointerConstant(
       PointerType ptr_constant,
       std::vector<std::uintptr_t>* pointer_check_addresses) {
-    llvm::Constant* constant = code_generator_->GetConstant(ptr_constant);
+    llvm::Constant* constant = codegen_utils_->GetConstant(ptr_constant);
 
     // Check type.
-    EXPECT_EQ(code_generator_->GetType<PointerType>(), constant->getType());
+    EXPECT_EQ(codegen_utils_->GetType<PointerType>(), constant->getType());
 
     if (ptr_constant == nullptr) {
       // Expect a NULL literal.
       EXPECT_TRUE(constant->isNullValue());
     } else {
       // Expect a GlobalVariable. This will be mapped to the actual external
-      // address when CodeGenerator::PrepareForExecution() is called. For now,
+      // address when CodeGenUtils::PrepareForExecution() is called. For now,
       // we generate a function that returns the (constant) address of the
       // GlobalVariable. Later on, we will compile all such functions and check
       // that they return the expected addresses.
       EXPECT_TRUE(llvm::isa<llvm::GlobalVariable>(constant));
 
       llvm::Function* global_accessor_fn
-          = code_generator_->CreateFunction<std::uintptr_t>(
+          = codegen_utils_->CreateFunction<std::uintptr_t>(
               GlobalConstantAccessorName(pointer_check_addresses->size()));
       llvm::BasicBlock* global_accessor_fn_body
-          = code_generator_->CreateBasicBlock("body", global_accessor_fn);
-      code_generator_->ir_builder()->SetInsertPoint(global_accessor_fn_body);
-      llvm::Value* global_addr = code_generator_->ir_builder()->CreatePtrToInt(
+          = codegen_utils_->CreateBasicBlock("body", global_accessor_fn);
+      codegen_utils_->ir_builder()->SetInsertPoint(global_accessor_fn_body);
+      llvm::Value* global_addr = codegen_utils_->ir_builder()->CreatePtrToInt(
           constant,
-          code_generator_->GetType<std::uintptr_t>());
-      code_generator_->ir_builder()->CreateRet(global_addr);
+          codegen_utils_->GetType<std::uintptr_t>());
+      codegen_utils_->ir_builder()->CreateRet(global_addr);
 
       // Verify function is well-formed.
       EXPECT_FALSE(llvm::verifyFunction(*global_accessor_fn));
@@ -776,7 +776,7 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerConstantTest. Tests
-  // CodeGenerator::GetConstant() by calling CheckGetSinglePointerConstant()
+  // CodeGenUtils::GetConstant() by calling CheckGetSinglePointerConstant()
   // for a 'ScalarType*' pointer pointing to NULL, to stack memory, and to heap
   // memory, and for a 'ScalarType**' pointer pointing to NULL, to stack
   // memory, and to heap memory.
@@ -806,7 +806,7 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for ExternalFunctionTest. Registers 'external_function' in
-  // 'code_generator_' and creates an LLVM wrapper function for it named
+  // 'codegen_utils_' and creates an LLVM wrapper function for it named
   // 'wrapper_function_name'. The wrapper function has the same type-signature
   // as 'external_function' and simply forwards its arguments as-is to
   // 'external_function' and returns back the same return value.
@@ -814,41 +814,41 @@ class CodeGeneratorTest : public ::testing::Test {
   void MakeWrapperFunction(
       ReturnType (*external_function)(ArgumentTypes...),
       const std::string& wrapper_function_name) {
-    // Register 'external_function' in 'code_generator_' and check that it has
+    // Register 'external_function' in 'codegen_utils_' and check that it has
     // the expected type-signature.
     llvm::Function* llvm_external_function
-        = code_generator_->RegisterExternalFunction(external_function);
+        = codegen_utils_->RegisterExternalFunction(external_function);
     ASSERT_NE(llvm_external_function, nullptr);
     EXPECT_EQ(
-        (code_generator_->GetFunctionType<ReturnType, ArgumentTypes...>()
+        (codegen_utils_->GetFunctionType<ReturnType, ArgumentTypes...>()
             ->getPointerTo()),
         llvm_external_function->getType());
 
-    // Create a wrapper function in 'code_generator_' with the same
+    // Create a wrapper function in 'codegen_utils_' with the same
     // type-signature that merely forwards its arguments to the external
     // function as-is.
     llvm::Function* wrapper_function
-        = code_generator_->CreateFunction<ReturnType, ArgumentTypes...>(
+        = codegen_utils_->CreateFunction<ReturnType, ArgumentTypes...>(
             wrapper_function_name);
 
     llvm::BasicBlock* wrapper_function_body
-        = code_generator_->CreateBasicBlock("wrapper_fn_body",
+        = codegen_utils_->CreateBasicBlock("wrapper_fn_body",
                                             wrapper_function);
 
-    code_generator_->ir_builder()->SetInsertPoint(wrapper_function_body);
+    codegen_utils_->ir_builder()->SetInsertPoint(wrapper_function_body);
     std::vector<llvm::Value*> forwarded_args;
     for (llvm::Argument& arg : wrapper_function->args()) {
       forwarded_args.push_back(&arg);
     }
-    llvm::CallInst* call = code_generator_->ir_builder()->CreateCall(
+    llvm::CallInst* call = codegen_utils_->ir_builder()->CreateCall(
         llvm_external_function,
         forwarded_args);
 
     // Return the result of the call, or void if the function returns void.
     if (std::is_same<ReturnType, void>::value) {
-      code_generator_->ir_builder()->CreateRetVoid();
+      codegen_utils_->ir_builder()->CreateRetVoid();
     } else {
-      code_generator_->ir_builder()->CreateRet(call);
+      codegen_utils_->ir_builder()->CreateRet(call);
     }
 
     // Check that the wrapper function is well-formed. LLVM verification
@@ -857,12 +857,12 @@ class CodeGeneratorTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerToMemberConstantTest. Verifies that
-  // CodeGenerator::GetPointerToMember() functions correctly for
+  // CodeGenUtils::GetPointerToMember() functions correctly for
   // 'pointers_to_members' by checking the type of the pointer generated when
   // accessing a member from a constant pointer to StructType and generating an
   // accessor function the returns the address of the member, recording the
   // expected address in '*pointer_check_addresses'. After all of the
-  // invocations of this method in a test, CodeGenerator::PrepareForExecution()
+  // invocations of this method in a test, CodeGenUtils::PrepareForExecution()
   // should be called to compile the accessor functions, then
   // FinishCheckingGlobalConstantPointers() should be called to make sure that
   // the accessor functions return the expected addresses.
@@ -875,24 +875,24 @@ class CodeGeneratorTest : public ::testing::Test {
       const std::size_t expected_offset,
       PointerToMemberTypes&&... pointers_to_members) {
     llvm::Constant* llvm_ptr_to_struct
-        = code_generator_->GetConstant(external_struct);
+        = codegen_utils_->GetConstant(external_struct);
 
     // Generate a function that returns the (constant) address of the member
     // field inside the struct.
     llvm::Function* global_member_accessor_fn
-        = code_generator_->CreateFunction<std::uintptr_t>(
+        = codegen_utils_->CreateFunction<std::uintptr_t>(
             GlobalConstantAccessorName(pointer_check_addresses->size()));
     llvm::BasicBlock* global_member_accessor_fn_body
-        = code_generator_->CreateBasicBlock("body", global_member_accessor_fn);
-    code_generator_->ir_builder()->SetInsertPoint(
+        = codegen_utils_->CreateBasicBlock("body", global_member_accessor_fn);
+    codegen_utils_->ir_builder()->SetInsertPoint(
         global_member_accessor_fn_body);
-    llvm::Value* member_ptr = code_generator_->GetPointerToMember(
+    llvm::Value* member_ptr = codegen_utils_->GetPointerToMember(
         llvm_ptr_to_struct,
         std::forward<PointerToMemberTypes>(pointers_to_members)...);
-    llvm::Value* member_address = code_generator_->ir_builder()->CreatePtrToInt(
+    llvm::Value* member_address = codegen_utils_->ir_builder()->CreatePtrToInt(
         member_ptr,
-        code_generator_->GetType<std::uintptr_t>());
-    code_generator_->ir_builder()->CreateRet(member_address);
+        codegen_utils_->GetType<std::uintptr_t>());
+    codegen_utils_->ir_builder()->CreateRet(member_address);
 
     // Verify accessor function is well-formed.
     EXPECT_FALSE(llvm::verifyFunction(*global_member_accessor_fn));
@@ -911,22 +911,22 @@ class CodeGeneratorTest : public ::testing::Test {
       const std::string& function_name,
       PointerToMemberTypes&&... pointers_to_members) {
     llvm::Function* accessor_function
-        = code_generator_->CreateFunction<MemberType, const StructType*>(
+        = codegen_utils_->CreateFunction<MemberType, const StructType*>(
             function_name);
     llvm::BasicBlock* accessor_function_body
-        = code_generator_->CreateBasicBlock("accessor_fn_body",
+        = codegen_utils_->CreateBasicBlock("accessor_fn_body",
                                             accessor_function);
-    code_generator_->ir_builder()->SetInsertPoint(accessor_function_body);
+    codegen_utils_->ir_builder()->SetInsertPoint(accessor_function_body);
 
     // Get pointer to member.
-    llvm::Value* member_ptr = code_generator_->GetPointerToMember(
+    llvm::Value* member_ptr = codegen_utils_->GetPointerToMember(
         ArgumentByPosition(accessor_function, 0),
         std::forward<PointerToMemberTypes>(pointers_to_members)...);
     // Actually load the value from the pointer.
     llvm::Value* member_value
-        = code_generator_->ir_builder()->CreateLoad(member_ptr);
+        = codegen_utils_->ir_builder()->CreateLoad(member_ptr);
     // Return the loaded value.
-    code_generator_->ir_builder()->CreateRet(member_value);
+    codegen_utils_->ir_builder()->CreateRet(member_value);
 
     // Check that the accessor function is well-formed. LLVM verification
     // functions return false if no errors are detected.
@@ -965,37 +965,37 @@ class CodeGeneratorTest : public ::testing::Test {
       const std::string& project_func_name,
       size_t* projection_indices, size_t projection_count) {
     llvm::Function* project_scalar_function
-      = code_generator_->CreateFunction<void, InputType*, InputType*>(
+      = codegen_utils_->CreateFunction<void, InputType*, InputType*>(
           project_func_name);
 
     // BasicBlocks for function entry.
-    llvm::BasicBlock* entry_block = code_generator_->CreateBasicBlock(
+    llvm::BasicBlock* entry_block = codegen_utils_->CreateBasicBlock(
         "entry", project_scalar_function);
     llvm::Value* input_array = ArgumentByPosition(project_scalar_function, 0);
     llvm::Value* output_array = ArgumentByPosition(project_scalar_function, 1);
-    code_generator_->ir_builder()->SetInsertPoint(entry_block);
+    codegen_utils_->ir_builder()->SetInsertPoint(entry_block);
 
     // Build loop unrolled projection code.
     for (size_t idx = 0; idx < projection_count; ++idx) {
         // The next address of the input array where we need to read.
         llvm::Value* next_address =
-          code_generator_->ir_builder()->CreateInBoundsGEP(input_array,
-            {code_generator_->GetConstant(projection_indices[idx])});
+          codegen_utils_->ir_builder()->CreateInBoundsGEP(input_array,
+            {codegen_utils_->GetConstant(projection_indices[idx])});
 
         // Load the value from the calculated input address.
         llvm::LoadInst* load_instruction =
-            code_generator_->ir_builder()->CreateLoad(next_address, "input");
+            codegen_utils_->ir_builder()->CreateLoad(next_address, "input");
 
         // Find the output address where we need to write our projected element.
         llvm::Value* next_output_address =
-            code_generator_->ir_builder()->CreateInBoundsGEP(output_array,
-              {code_generator_->GetConstant(idx)});
+            codegen_utils_->ir_builder()->CreateInBoundsGEP(output_array,
+              {codegen_utils_->GetConstant(idx)});
 
         // Store the projecetd element into the output address.
-        code_generator_->ir_builder()-> CreateStore(
+        codegen_utils_->ir_builder()-> CreateStore(
           load_instruction, next_output_address, "output");
      }
-     code_generator_->ir_builder()->CreateRetVoid();
+     codegen_utils_->ir_builder()->CreateRetVoid();
   }
 
   // Helper method for ProjectScalarArrayTest. For given type generate random
@@ -1015,11 +1015,11 @@ class CodeGeneratorTest : public ::testing::Test {
         proj_indices, projection_count);
 
     // Prepare for execution.
-    EXPECT_TRUE(code_generator_->PrepareForExecution(
-        CodeGenerator::OptimizationLevel::kNone, true));
+    EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+        CodeGenUtils::OptimizationLevel::kNone, true));
 
     void (*project_scalar_function_compiled)(InputType*, InputType*)
-         = code_generator_->GetFunctionPointer<void, InputType*, InputType*>(
+         = codegen_utils_->GetFunctionPointer<void, InputType*, InputType*>(
              "func_project");
 
     // Call the generated projection function
@@ -1035,25 +1035,25 @@ class CodeGeneratorTest : public ::testing::Test {
     delete[] output_array;
   }
 
-  std::unique_ptr<CodeGenerator> code_generator_;
+  std::unique_ptr<CodeGenUtils> codegen_utils_;
 };
 
-typedef CodeGeneratorTest CodeGeneratorDeathTest;
+typedef CodeGenUtilsTest CodeGenUtilsDeathTest;
 
-TEST_F(CodeGeneratorTest, InitializationTest) {
-  EXPECT_NE(code_generator_->ir_builder(), nullptr);
-  ASSERT_NE(code_generator_->module(), nullptr);
+TEST_F(CodeGenUtilsTest, InitializationTest) {
+  EXPECT_NE(codegen_utils_->ir_builder(), nullptr);
+  ASSERT_NE(codegen_utils_->module(), nullptr);
   EXPECT_EQ(std::string("test_module"),
-            code_generator_->module()->getModuleIdentifier());
+            codegen_utils_->module()->getModuleIdentifier());
 }
 
-TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
+TEST_F(CodeGenUtilsTest, GetScalarTypeTest) {
   // Check void.
-  llvm::Type* llvm_type = code_generator_->GetType<void>();
+  llvm::Type* llvm_type = codegen_utils_->GetType<void>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isVoidTy());
 
-  AnnotatedType annotated_type = code_generator_->GetAnnotatedType<void>();
+  AnnotatedType annotated_type = codegen_utils_->GetAnnotatedType<void>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isVoidTy());
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1067,11 +1067,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
   // Check bool (represented as i1 in LLVM IR).
-  llvm_type = code_generator_->GetType<bool>();
+  llvm_type = codegen_utils_->GetType<bool>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isIntegerTy(1));
 
-  annotated_type = code_generator_->GetAnnotatedType<bool>();
+  annotated_type = codegen_utils_->GetAnnotatedType<bool>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isIntegerTy(1));
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1084,11 +1084,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   ASSERT_EQ(1u, annotated_type.is_volatile.size());
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
-  llvm_type = code_generator_->GetType<const bool>();
+  llvm_type = codegen_utils_->GetType<const bool>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isIntegerTy(1));
 
-  annotated_type = code_generator_->GetAnnotatedType<const bool>();
+  annotated_type = codegen_utils_->GetAnnotatedType<const bool>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isIntegerTy(1));
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1102,11 +1102,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
   // Check 32-bit float.
-  llvm_type = code_generator_->GetType<float>();
+  llvm_type = codegen_utils_->GetType<float>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isFloatTy());
 
-  annotated_type = code_generator_->GetAnnotatedType<float>();
+  annotated_type = codegen_utils_->GetAnnotatedType<float>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isFloatTy());
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1119,11 +1119,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   ASSERT_EQ(1u, annotated_type.is_volatile.size());
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
-  llvm_type = code_generator_->GetType<const float>();
+  llvm_type = codegen_utils_->GetType<const float>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isFloatTy());
 
-  annotated_type = code_generator_->GetAnnotatedType<const float>();
+  annotated_type = codegen_utils_->GetAnnotatedType<const float>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isFloatTy());
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1137,11 +1137,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
   // Check 64-bit double.
-  llvm_type = code_generator_->GetType<double>();
+  llvm_type = codegen_utils_->GetType<double>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isDoubleTy());
 
-  annotated_type = code_generator_->GetAnnotatedType<double>();
+  annotated_type = codegen_utils_->GetAnnotatedType<double>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isDoubleTy());
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1154,11 +1154,11 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   ASSERT_EQ(1u, annotated_type.is_volatile.size());
   EXPECT_FALSE(annotated_type.is_volatile.front());
 
-  llvm_type = code_generator_->GetType<const double>();
+  llvm_type = codegen_utils_->GetType<const double>();
   ASSERT_NE(llvm_type, nullptr);
   EXPECT_TRUE(llvm_type->isDoubleTy());
 
-  annotated_type = code_generator_->GetAnnotatedType<const double>();
+  annotated_type = codegen_utils_->GetAnnotatedType<const double>();
   ASSERT_NE(annotated_type.llvm_type, nullptr);
   EXPECT_TRUE(annotated_type.llvm_type->isDoubleTy());
   EXPECT_FALSE(annotated_type.is_voidptr);
@@ -1239,7 +1239,7 @@ TEST_F(CodeGeneratorTest, GetScalarTypeTest) {
   CheckGetEnumType<StronglyTypedEnumUint64, std::uint64_t>();
 }
 
-TEST_F(CodeGeneratorTest, GetPointerTypeTest) {
+TEST_F(CodeGenUtilsTest, GetPointerTypeTest) {
   // Check void*. Void pointers are a special case, because convention in the
   // LLVM type system is to use i8* (equivalent to char* in C) for all
   // "untyped" pointers.
@@ -1424,16 +1424,16 @@ TEST_F(CodeGeneratorTest, GetPointerTypeTest) {
           pointer_to_pointer_to_void_check_lambda);
 }
 
-TEST_F(CodeGeneratorTest, GetScalarConstantTest) {
+TEST_F(CodeGenUtilsTest, GetScalarConstantTest) {
   // Check bool constants.
-  llvm::Constant* constant = code_generator_->GetConstant(false);
+  llvm::Constant* constant = codegen_utils_->GetConstant(false);
   // Verify the constant's type.
-  EXPECT_EQ(code_generator_->GetType<bool>(), constant->getType());
+  EXPECT_EQ(codegen_utils_->GetType<bool>(), constant->getType());
   // Verify the constant's value.
   EXPECT_TRUE(constant->isZeroValue());
 
-  constant = code_generator_->GetConstant(true);
-  EXPECT_EQ(code_generator_->GetType<bool>(), constant->getType());
+  constant = codegen_utils_->GetConstant(true);
+  EXPECT_EQ(codegen_utils_->GetType<bool>(), constant->getType());
   EXPECT_TRUE(constant->isOneValue());
 
   // Check the C built-in integer types, and their explicitly signed and
@@ -1509,7 +1509,7 @@ TEST_F(CodeGeneratorTest, GetScalarConstantTest) {
        StronglyTypedEnumUint64::kCaseC});
 }
 
-TEST_F(CodeGeneratorTest, GetPointerConstantTest) {
+TEST_F(CodeGenUtilsTest, GetPointerConstantTest) {
   // Remember the addresses of pointer constants, in order, that we expect check
   // functions to return.
   std::vector<std::uintptr_t> pointer_check_addresses;
@@ -1623,107 +1623,107 @@ TEST_F(CodeGeneratorTest, GetPointerConstantTest) {
   // The various invocations of CheckGetSinglePointerConstant() above created a
   // bunch of accessor functions that we will now compile and use to check that
   // the addresses of global variables are as expected.
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
-  ASSERT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+  ASSERT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
   FinishCheckingGlobalConstantPointers(pointer_check_addresses);
 }
 
-TEST_F(CodeGeneratorTest, GetFunctionTypeTest) {
+TEST_F(CodeGenUtilsTest, GetFunctionTypeTest) {
   // Simple function with no parameters that returns void.
-  llvm::FunctionType* fn_type = code_generator_->GetFunctionType<void>();
+  llvm::FunctionType* fn_type = codegen_utils_->GetFunctionType<void>();
   ASSERT_NE(fn_type, nullptr);
-  EXPECT_EQ(code_generator_->GetType<void>(), fn_type->getReturnType());
+  EXPECT_EQ(codegen_utils_->GetType<void>(), fn_type->getReturnType());
   EXPECT_EQ(0u, fn_type->getNumParams());
 
   // Function that takes a few different scalar parameters and returns double.
-  fn_type = code_generator_->GetFunctionType<double,
+  fn_type = codegen_utils_->GetFunctionType<double,
                                              int,
                                              float,
                                              std::size_t,
                                              SignedStronglyTypedEnum>();
   ASSERT_NE(fn_type, nullptr);
-  EXPECT_EQ(code_generator_->GetType<double>(), fn_type->getReturnType());
+  EXPECT_EQ(codegen_utils_->GetType<double>(), fn_type->getReturnType());
   ASSERT_EQ(4u, fn_type->getNumParams());
-  EXPECT_EQ(code_generator_->GetType<int>(), fn_type->getParamType(0));
-  EXPECT_EQ(code_generator_->GetType<float>(), fn_type->getParamType(1));
-  EXPECT_EQ(code_generator_->GetType<std::size_t>(), fn_type->getParamType(2));
-  EXPECT_EQ(code_generator_->GetType<SignedStronglyTypedEnum>(),
+  EXPECT_EQ(codegen_utils_->GetType<int>(), fn_type->getParamType(0));
+  EXPECT_EQ(codegen_utils_->GetType<float>(), fn_type->getParamType(1));
+  EXPECT_EQ(codegen_utils_->GetType<std::size_t>(), fn_type->getParamType(2));
+  EXPECT_EQ(codegen_utils_->GetType<SignedStronglyTypedEnum>(),
             fn_type->getParamType(3));
 
   // A mix of pointer and reference parameters.
-  fn_type = code_generator_->GetFunctionType<void*,
+  fn_type = codegen_utils_->GetFunctionType<void*,
                                              const int&,
                                              float&,
                                              const std::size_t*,
                                              SignedStronglyTypedEnum*>();
   ASSERT_NE(fn_type, nullptr);
-  EXPECT_EQ(code_generator_->GetType<void*>(), fn_type->getReturnType());
+  EXPECT_EQ(codegen_utils_->GetType<void*>(), fn_type->getReturnType());
   ASSERT_EQ(4u, fn_type->getNumParams());
-  EXPECT_EQ(code_generator_->GetType<const int&>(), fn_type->getParamType(0));
-  EXPECT_EQ(code_generator_->GetType<float&>(), fn_type->getParamType(1));
-  EXPECT_EQ(code_generator_->GetType<const std::size_t*>(),
+  EXPECT_EQ(codegen_utils_->GetType<const int&>(), fn_type->getParamType(0));
+  EXPECT_EQ(codegen_utils_->GetType<float&>(), fn_type->getParamType(1));
+  EXPECT_EQ(codegen_utils_->GetType<const std::size_t*>(),
             fn_type->getParamType(2));
-  EXPECT_EQ(code_generator_->GetType<SignedStronglyTypedEnum*>(),
+  EXPECT_EQ(codegen_utils_->GetType<SignedStronglyTypedEnum*>(),
             fn_type->getParamType(3));
 
   // Pointers and references to user-defined structs and classes.
-  fn_type = code_generator_->GetFunctionType<DummyAbstractBaseClass*,
+  fn_type = codegen_utils_->GetFunctionType<DummyAbstractBaseClass*,
                                              const Squarer&,
                                              Negater&,
                                              DummyStruct*>();
   ASSERT_NE(fn_type, nullptr);
-  EXPECT_EQ(code_generator_->GetType<DummyAbstractBaseClass*>(),
+  EXPECT_EQ(codegen_utils_->GetType<DummyAbstractBaseClass*>(),
             fn_type->getReturnType());
   ASSERT_EQ(3u, fn_type->getNumParams());
-  EXPECT_EQ(code_generator_->GetType<const Squarer&>(),
+  EXPECT_EQ(codegen_utils_->GetType<const Squarer&>(),
             fn_type->getParamType(0));
-  EXPECT_EQ(code_generator_->GetType<Negater&>(),
+  EXPECT_EQ(codegen_utils_->GetType<Negater&>(),
             fn_type->getParamType(1));
-  EXPECT_EQ(code_generator_->GetType<DummyStruct*>(),
+  EXPECT_EQ(codegen_utils_->GetType<DummyStruct*>(),
             fn_type->getParamType(2));
 }
 
-TEST_F(CodeGeneratorTest, TrivialCompilationTest) {
+TEST_F(CodeGenUtilsTest, TrivialCompilationTest) {
   // Create an IR function that takes no arguments and returns int.
   llvm::Function* simple_fn
-      = code_generator_->CreateFunction<int>("simple_fn");
+      = codegen_utils_->CreateFunction<int>("simple_fn");
 
   // Construct a single BasicBlock for the function's body.
   llvm::BasicBlock* simple_fn_body
-      = code_generator_->CreateBasicBlock("simple_fn_body", simple_fn);
+      = codegen_utils_->CreateBasicBlock("simple_fn_body", simple_fn);
 
   // Create a return instruction that returns the constant value '42'.
-  code_generator_->ir_builder()->SetInsertPoint(simple_fn_body);
-  code_generator_->ir_builder()->CreateRet(
-      code_generator_->GetConstant<int>(42));
+  codegen_utils_->ir_builder()->SetInsertPoint(simple_fn_body);
+  codegen_utils_->ir_builder()->CreateRet(
+      codegen_utils_->GetConstant<int>(42));
 
   // Check that the function and the module are both well-formed (note that the
   // LLVM verification functions return false to indicate success).
   EXPECT_FALSE(llvm::verifyFunction(*simple_fn));
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
 
   // Prepare generated code for execution.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
-  EXPECT_EQ(nullptr, code_generator_->module());
+  EXPECT_EQ(nullptr, codegen_utils_->module());
 
   // Try looking up function names that don't exist.
-  EXPECT_EQ(nullptr, code_generator_->GetFunctionPointer<void>("foo"));
+  EXPECT_EQ(nullptr, codegen_utils_->GetFunctionPointer<void>("foo"));
   EXPECT_EQ(nullptr,
-            code_generator_->GetFunctionPointer<void>("simple_fn_body"));
+            codegen_utils_->GetFunctionPointer<void>("simple_fn_body"));
 
   // Cast to the actual function type and call the generated function.
   int (*function_ptr)()
-      = code_generator_->GetFunctionPointer<int>("simple_fn");
+      = codegen_utils_->GetFunctionPointer<int>("simple_fn");
   ASSERT_NE(function_ptr, nullptr);
 
   EXPECT_EQ(42, (*function_ptr)());
 }
 
-TEST_F(CodeGeneratorTest, ExternalFunctionTest) {
+TEST_F(CodeGenUtilsTest, ExternalFunctionTest) {
   // Test a function with overloads for different types (we will explicitly use
   // the version of std::fabs() for doubles).
   MakeWrapperFunction<double, double>(&std::fabs,
@@ -1737,14 +1737,14 @@ TEST_F(CodeGeneratorTest, ExternalFunctionTest) {
 
   // Check that the module is well-formed and prepare the generated wrapper
   // functions for execution.
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
 
   // Try calling std::fabs() through the generated wrapper.
   double (*fabs_double_wrapper)(double)  // NOLINT(readability/casting)
-      = code_generator_->GetFunctionPointer<double, double>(
+      = codegen_utils_->GetFunctionPointer<double, double>(
           "fabs_double_wrapper");
   ASSERT_NE(fabs_double_wrapper, nullptr);
   EXPECT_EQ(12.34, (*fabs_double_wrapper)(12.34));
@@ -1752,7 +1752,7 @@ TEST_F(CodeGeneratorTest, ExternalFunctionTest) {
 
   // Try calling std::mktime() through the generated wrapper.
   std::time_t (*mktime_wrapper)(std::tm*)
-      = code_generator_->GetFunctionPointer<std::time_t, std::tm*>(
+      = codegen_utils_->GetFunctionPointer<std::time_t, std::tm*>(
           "mktime_wrapper");
   ASSERT_NE(mktime_wrapper, nullptr);
   std::tm broken_time = {};
@@ -1763,28 +1763,28 @@ TEST_F(CodeGeneratorTest, ExternalFunctionTest) {
 
   StaticIntWrapper::Set(0);
   void (*static_int_set_wrapper)(const int)
-      = code_generator_->GetFunctionPointer<void, const int>(
+      = codegen_utils_->GetFunctionPointer<void, const int>(
           "StaticIntWrapper::Set_wrapper");
   ASSERT_NE(static_int_set_wrapper, nullptr);
   (*static_int_set_wrapper)(42);
   EXPECT_EQ(42, StaticIntWrapper::Get());
 }
 
-TEST_F(CodeGeneratorTest, RecursionTest) {
+TEST_F(CodeGenUtilsTest, RecursionTest) {
   // Test a version of the factorial function that works by recursion.
   llvm::Function* factorial_recursive
-      = code_generator_->CreateFunction<unsigned, unsigned>(
+      = codegen_utils_->CreateFunction<unsigned, unsigned>(
           "factorial_recursive");
 
   // Create a BasicBlock for the function's entry point that will branch to a
   // base case and a recursive case.
-  llvm::BasicBlock* entry = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* entry = codegen_utils_->CreateBasicBlock(
       "entry",
       factorial_recursive);
-  llvm::BasicBlock* base_case = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* base_case = codegen_utils_->CreateBasicBlock(
       "base_case",
       factorial_recursive);
-  llvm::BasicBlock* recursive_case = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* recursive_case = codegen_utils_->CreateBasicBlock(
       "recursive_case",
       factorial_recursive);
 
@@ -1793,43 +1793,43 @@ TEST_F(CodeGeneratorTest, RecursionTest) {
 
   // Check if we have reached the base-case (argument == 0) and conditionally
   // branch.
-  code_generator_->ir_builder()->SetInsertPoint(entry);
-  llvm::Value* arg_is_zero = code_generator_->ir_builder()->CreateICmpEQ(
+  codegen_utils_->ir_builder()->SetInsertPoint(entry);
+  llvm::Value* arg_is_zero = codegen_utils_->ir_builder()->CreateICmpEQ(
       argument,
-      code_generator_->GetConstant(0u));
-  code_generator_->ir_builder()->CreateCondBr(arg_is_zero,
+      codegen_utils_->GetConstant(0u));
+  codegen_utils_->ir_builder()->CreateCondBr(arg_is_zero,
                                               base_case,
                                               recursive_case);
 
   // Base case: 0! = 1.
-  code_generator_->ir_builder()->SetInsertPoint(base_case);
-  code_generator_->ir_builder()->CreateRet(code_generator_->GetConstant(1u));
+  codegen_utils_->ir_builder()->SetInsertPoint(base_case);
+  codegen_utils_->ir_builder()->CreateRet(codegen_utils_->GetConstant(1u));
 
   // Recursive case: N! = N * (N - 1)!
-  code_generator_->ir_builder()->SetInsertPoint(recursive_case);
+  codegen_utils_->ir_builder()->SetInsertPoint(recursive_case);
 
   std::vector<llvm::Value*> recursive_call_args;
-  recursive_call_args.push_back(code_generator_->ir_builder()->CreateSub(
+  recursive_call_args.push_back(codegen_utils_->ir_builder()->CreateSub(
       argument,
-      code_generator_->GetConstant(1u)));
-  llvm::Value* child_result = code_generator_->ir_builder()->CreateCall(
+      codegen_utils_->GetConstant(1u)));
+  llvm::Value* child_result = codegen_utils_->ir_builder()->CreateCall(
       factorial_recursive,
       recursive_call_args);
 
-  llvm::Value* product = code_generator_->ir_builder()->CreateMul(argument,
+  llvm::Value* product = codegen_utils_->ir_builder()->CreateMul(argument,
                                                                   child_result);
-  code_generator_->ir_builder()->CreateRet(product);
+  codegen_utils_->ir_builder()->CreateRet(product);
 
   // Verify function and module.
   EXPECT_FALSE(llvm::verifyFunction(*factorial_recursive));
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
 
   // Prepare for execution.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
   unsigned (*factorial_recursive_compiled)(unsigned)
-      = code_generator_->GetFunctionPointer<unsigned, unsigned>(
+      = codegen_utils_->GetFunctionPointer<unsigned, unsigned>(
           "factorial_recursive");
 
   // Test out the compiled function.
@@ -1839,86 +1839,86 @@ TEST_F(CodeGeneratorTest, RecursionTest) {
             (*factorial_recursive_compiled)(7u));
 }
 
-TEST_F(CodeGeneratorTest, SwitchTest) {
+TEST_F(CodeGenUtilsTest, SwitchTest) {
   // Test that generates IR code with a SWITCH statement.
   // It takes a char as input and returns 1 if input = 'A',
   // 2 if input is 'B'; -1 otherwise.
   llvm::Function* switch_function
-      = code_generator_->CreateFunction<int, char>(
+      = codegen_utils_->CreateFunction<int, char>(
           "switch_function");
 
   // BasicBlocks for function entry, for each case of switch instruction,
   // for the default case, and for function termination
   // where an integer is returned.
-  llvm::BasicBlock* entry_block = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* entry_block = codegen_utils_->CreateBasicBlock(
       "entry",
       switch_function);
 
-  llvm::BasicBlock* A_block = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* A_block = codegen_utils_->CreateBasicBlock(
       "A_block",
       switch_function);
 
-  llvm::BasicBlock* B_block = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* B_block = codegen_utils_->CreateBasicBlock(
       "B_block",
       switch_function);
 
-  llvm::BasicBlock* default_block = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* default_block = codegen_utils_->CreateBasicBlock(
       "default",
       switch_function);
 
-  llvm::BasicBlock* return_block = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* return_block = codegen_utils_->CreateBasicBlock(
       "return",
       switch_function);
 
   llvm::Value* argument = ArgumentByPosition(switch_function, 0);
 
   // Switch instruction is located in the entry point.
-  code_generator_->ir_builder()->SetInsertPoint(entry_block);
+  codegen_utils_->ir_builder()->SetInsertPoint(entry_block);
   llvm::SwitchInst* switch_instruction
-    = code_generator_->ir_builder()->CreateSwitch(argument, default_block, 3);
+    = codegen_utils_->ir_builder()->CreateSwitch(argument, default_block, 3);
 
   // Add switch cases.
   llvm::ConstantInt* val_a = static_cast<llvm::ConstantInt*>(
-      code_generator_->GetConstant('A'));
+      codegen_utils_->GetConstant('A'));
   ASSERT_TRUE(llvm::isa<llvm::ConstantInt>(val_a));
   switch_instruction->addCase(val_a, A_block);
 
   llvm::ConstantInt* val_b = static_cast<llvm::ConstantInt*>(
-      code_generator_->GetConstant('B'));
+      codegen_utils_->GetConstant('B'));
   ASSERT_TRUE(llvm::isa<llvm::ConstantInt>(val_b));
   switch_instruction->addCase(val_b, B_block);
 
   // All switch cases jump to return block.
-  code_generator_->ir_builder()->SetInsertPoint(default_block);
-  code_generator_->ir_builder()->CreateBr(return_block);
+  codegen_utils_->ir_builder()->SetInsertPoint(default_block);
+  codegen_utils_->ir_builder()->CreateBr(return_block);
 
-  code_generator_->ir_builder()->SetInsertPoint(A_block);
-  code_generator_->ir_builder()->CreateBr(return_block);
+  codegen_utils_->ir_builder()->SetInsertPoint(A_block);
+  codegen_utils_->ir_builder()->CreateBr(return_block);
 
-  code_generator_->ir_builder()->SetInsertPoint(B_block);
-  code_generator_->ir_builder()->CreateBr(return_block);
+  codegen_utils_->ir_builder()->SetInsertPoint(B_block);
+  codegen_utils_->ir_builder()->CreateBr(return_block);
 
   // Add incoming edges from switch cases to return block,
   // where each case sends to return block the proper value.
-  code_generator_->ir_builder()->SetInsertPoint(return_block);
-  llvm::PHINode* return_node = code_generator_->ir_builder()->CreatePHI(
-      code_generator_->GetType<int>(), 3);
-  return_node->addIncoming(code_generator_->GetConstant(-1), default_block);
-  return_node->addIncoming(code_generator_->GetConstant(1), A_block);
-  return_node->addIncoming(code_generator_->GetConstant(2), B_block);
-  code_generator_->ir_builder()->CreateRet(return_node);
+  codegen_utils_->ir_builder()->SetInsertPoint(return_block);
+  llvm::PHINode* return_node = codegen_utils_->ir_builder()->CreatePHI(
+      codegen_utils_->GetType<int>(), 3);
+  return_node->addIncoming(codegen_utils_->GetConstant(-1), default_block);
+  return_node->addIncoming(codegen_utils_->GetConstant(1), A_block);
+  return_node->addIncoming(codegen_utils_->GetConstant(2), B_block);
+  codegen_utils_->ir_builder()->CreateRet(return_node);
 
   // Verify function and module.
   EXPECT_FALSE(llvm::verifyFunction(*switch_function));
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
 
   // Prepare for execution.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
 
   int (*switch_function_compiled)(char)  // NOLINT(readability/casting)
-      = code_generator_->GetFunctionPointer<int, char>(
+      = codegen_utils_->GetFunctionPointer<int, char>(
           "switch_function");
 
   // Test out the compiled function.
@@ -1927,42 +1927,42 @@ TEST_F(CodeGeneratorTest, SwitchTest) {
   EXPECT_EQ(-1, (*switch_function_compiled)('C'));
 }
 
-TEST_F(CodeGeneratorTest, ProjectScalarIntArrayTest) {
+TEST_F(CodeGenUtilsTest, ProjectScalarIntArrayTest) {
   ProjectScalarArrayTestHelper<int>();
 }
 
-TEST_F(CodeGeneratorTest, ProjectScalarInt16ArrayTest) {
+TEST_F(CodeGenUtilsTest, ProjectScalarInt16ArrayTest) {
   ProjectScalarArrayTestHelper<int16_t>();
 }
 
-TEST_F(CodeGeneratorTest, ProjectScalarInt64ArrayTest) {
+TEST_F(CodeGenUtilsTest, ProjectScalarInt64ArrayTest) {
   ProjectScalarArrayTestHelper<int64_t>();
 }
 
-TEST_F(CodeGeneratorTest, ProjectScalarCharArrayTest) {
+TEST_F(CodeGenUtilsTest, ProjectScalarCharArrayTest) {
   ProjectScalarArrayTestHelper<char>();
 }
 
-TEST_F(CodeGeneratorTest, IterationTest) {
+TEST_F(CodeGenUtilsTest, IterationTest) {
   // Test a version of the factorial function works with an iterative loop.
   llvm::Function* factorial_iterative
-      = code_generator_->CreateFunction<unsigned, unsigned>(
+      = codegen_utils_->CreateFunction<unsigned, unsigned>(
           "factorial_iterative");
 
   // BasicBlocks for function entry, for the start of the loop where the
   // termination condition is checked, for the loop body where running variables
   // are updated, and for function termination where the computed product is
   // returned.
-  llvm::BasicBlock* entry = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* entry = codegen_utils_->CreateBasicBlock(
       "entry",
       factorial_iterative);
-  llvm::BasicBlock* loop_start = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* loop_start = codegen_utils_->CreateBasicBlock(
       "loop_start",
       factorial_iterative);
-  llvm::BasicBlock* loop_computation = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* loop_computation = codegen_utils_->CreateBasicBlock(
       "loop_computation",
       factorial_iterative);
-  llvm::BasicBlock* terminus = code_generator_->CreateBasicBlock(
+  llvm::BasicBlock* terminus = codegen_utils_->CreateBasicBlock(
       "terminus",
       factorial_iterative);
 
@@ -1972,43 +1972,43 @@ TEST_F(CodeGeneratorTest, IterationTest) {
   // Entry point unconditionally enters the loop. Note that we can't just make
   // "loop_start" the entry point for the function, because it has PHI-nodes
   // that need to be assigned based on predecessor BasicBlocks.
-  code_generator_->ir_builder()->SetInsertPoint(entry);
-  code_generator_->ir_builder()->CreateBr(loop_start);
+  codegen_utils_->ir_builder()->SetInsertPoint(entry);
+  codegen_utils_->ir_builder()->CreateBr(loop_start);
 
   // Create PHI nodes to represent the current factor (starting at the
   // argument's value and counting down to zero) and the current product
   // (starting at one and getting multiplied for each iteration of the loop).
-  code_generator_->ir_builder()->SetInsertPoint(loop_start);
+  codegen_utils_->ir_builder()->SetInsertPoint(loop_start);
 
-  llvm::PHINode* current_factor = code_generator_->ir_builder()->CreatePHI(
-      code_generator_->GetType<unsigned>(), 2);
+  llvm::PHINode* current_factor = codegen_utils_->ir_builder()->CreatePHI(
+      codegen_utils_->GetType<unsigned>(), 2);
   current_factor->addIncoming(argument, entry);
 
-  llvm::PHINode* current_product = code_generator_->ir_builder()->CreatePHI(
-      code_generator_->GetType<unsigned>(), 2);
-  current_product->addIncoming(code_generator_->GetConstant(1u), entry);
+  llvm::PHINode* current_product = codegen_utils_->ir_builder()->CreatePHI(
+      codegen_utils_->GetType<unsigned>(), 2);
+  current_product->addIncoming(codegen_utils_->GetConstant(1u), entry);
 
   // If 'current_factor' has reached zero, break out of the loop. Otherwise
   // proceed to "loop_computation" to compute the factor and the product for the
   // next iteration.
   llvm::Value* current_factor_is_zero
-      = code_generator_->ir_builder()->CreateICmpEQ(
+      = codegen_utils_->ir_builder()->CreateICmpEQ(
           current_factor,
-          code_generator_->GetConstant(0u));
-  code_generator_->ir_builder()->CreateCondBr(current_factor_is_zero,
+          codegen_utils_->GetConstant(0u));
+  codegen_utils_->ir_builder()->CreateCondBr(current_factor_is_zero,
                                               terminus,
                                               loop_computation);
 
   // Compute values for the next iteration of the loop and go back to
   // "loop_start".
-  code_generator_->ir_builder()->SetInsertPoint(loop_computation);
-  llvm::Value* next_factor = code_generator_->ir_builder()->CreateSub(
+  codegen_utils_->ir_builder()->SetInsertPoint(loop_computation);
+  llvm::Value* next_factor = codegen_utils_->ir_builder()->CreateSub(
       current_factor,
-      code_generator_->GetConstant(1u));
-  llvm::Value* next_product = code_generator_->ir_builder()->CreateMul(
+      codegen_utils_->GetConstant(1u));
+  llvm::Value* next_product = codegen_utils_->ir_builder()->CreateMul(
       current_factor,
       current_product);
-  code_generator_->ir_builder()->CreateBr(loop_start);
+  codegen_utils_->ir_builder()->CreateBr(loop_start);
 
   // Add incoming edges to the PHI nodes in "loop_start" for the newly-computed
   // values.
@@ -2016,19 +2016,19 @@ TEST_F(CodeGeneratorTest, IterationTest) {
   current_product->addIncoming(next_product, loop_computation);
 
   // Terminus just returns the computed product.
-  code_generator_->ir_builder()->SetInsertPoint(terminus);
-  code_generator_->ir_builder()->CreateRet(current_product);
+  codegen_utils_->ir_builder()->SetInsertPoint(terminus);
+  codegen_utils_->ir_builder()->CreateRet(current_product);
 
   // Verify function and module.
   EXPECT_FALSE(llvm::verifyFunction(*factorial_iterative));
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
 
   // Prepare for execution.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
   unsigned (*factorial_iterative_compiled)(unsigned)
-      = code_generator_->GetFunctionPointer<unsigned, unsigned>(
+      = codegen_utils_->GetFunctionPointer<unsigned, unsigned>(
           "factorial_iterative");
 
   // Test out the compiled function.
@@ -2070,9 +2070,9 @@ TEST_F(CodeGeneratorTest, IterationTest) {
       &std::remove_reference<decltype((struct_ptr)->top_element_name)>::type   \
           ::nested_element_name)
 
-// Test for CodeGenerator::GetPointerToMember() with constant pointers to
+// Test for CodeGenUtils::GetPointerToMember() with constant pointers to
 // external structs.
-TEST_F(CodeGeneratorTest, GetPointerToMemberConstantTest) {
+TEST_F(CodeGenUtilsTest, GetPointerToMemberConstantTest) {
   // Remember the addresses of pointer constants, in order, that we expect check
   // functions to return.
   std::vector<std::uintptr_t> pointer_check_addresses;
@@ -2098,7 +2098,7 @@ TEST_F(CodeGeneratorTest, GetPointerToMemberConstantTest) {
                                                heap_struct.get(),
                                                0);
 
-  // A NULL pointer also works, since CodeGenerator::GetPointerToMember() only
+  // A NULL pointer also works, since CodeGenUtils::GetPointerToMember() only
   // does address computation and doesn't dereference anything.
   GPCODEGEN_TEST_GET_POINTER_TO_STRUCT_ELEMENT(
       static_cast<DummyStruct*>(nullptr),
@@ -2173,9 +2173,9 @@ TEST_F(CodeGeneratorTest, GetPointerToMemberConstantTest) {
   // Now we compile and call the various constant-accessor functions that were
   // generated in the course of this test, checking that they return the
   // expected addresses of member fields.
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
-  ASSERT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+  ASSERT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
   FinishCheckingGlobalConstantPointers(pointer_check_addresses);
 }
@@ -2183,7 +2183,7 @@ TEST_F(CodeGeneratorTest, GetPointerToMemberConstantTest) {
 #undef GPCODEGEN_TEST_GET_POINTER_TO_NESTED_STRUCT_ELEMENT
 #undef GPCODEGEN_TEST_GET_POINTER_TO_STRUCT_ELEMENT
 
-TEST_F(CodeGeneratorTest, GetPointerToMemberTest) {
+TEST_F(CodeGenUtilsTest, GetPointerToMemberTest) {
   // Create some accessor functions that load the value of fields in a struct
   // passed in as a pointer.
   MakeStructMemberAccessorFunction<DummyStruct, int>(
@@ -2197,23 +2197,23 @@ TEST_F(CodeGeneratorTest, GetPointerToMemberTest) {
       &DummyStruct::double_field);
 
   // Check that module is well-formed, then compile.
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
 
   int (*Get_DummyStruct_int_field)(const DummyStruct*)
-      = code_generator_->GetFunctionPointer<int, const DummyStruct*>(
+      = codegen_utils_->GetFunctionPointer<int, const DummyStruct*>(
           "Get_DummyStruct::int_field");
   ASSERT_NE(Get_DummyStruct_int_field, nullptr);
 
   bool (*Get_DummyStruct_bool_field)(const DummyStruct*)
-      = code_generator_->GetFunctionPointer<bool, const DummyStruct*>(
+      = codegen_utils_->GetFunctionPointer<bool, const DummyStruct*>(
           "Get_DummyStruct::bool_field");
   ASSERT_NE(Get_DummyStruct_bool_field, nullptr);
 
   double (*Get_DummyStruct_double_field)(const DummyStruct*)
-      = code_generator_->GetFunctionPointer<double, const DummyStruct*>(
+      = codegen_utils_->GetFunctionPointer<double, const DummyStruct*>(
           "Get_DummyStruct::double_field");
   ASSERT_NE(Get_DummyStruct_double_field, nullptr);
 
@@ -2235,40 +2235,40 @@ TEST_F(CodeGeneratorTest, GetPointerToMemberTest) {
   EXPECT_EQ(1e100, (*Get_DummyStruct_double_field)(&test_struct));
 }
 
-TEST_F(CodeGeneratorTest, OptimizationTest) {
+TEST_F(CodeGenUtilsTest, OptimizationTest) {
   // Create an ultra-simple function that just adds 2 ints. We expect this to be
   // automatically inlined at call sites during optimization.
   llvm::Function* add2_func
-      = code_generator_->CreateFunction<int, int, int>("add2");
-  llvm::BasicBlock* add2_body = code_generator_->CreateBasicBlock("body",
+      = codegen_utils_->CreateFunction<int, int, int>("add2");
+  llvm::BasicBlock* add2_body = codegen_utils_->CreateBasicBlock("body",
                                                                   add2_func);
-  code_generator_->ir_builder()->SetInsertPoint(add2_body);
-  llvm::Value* add2_sum = code_generator_->ir_builder()->CreateAdd(
+  codegen_utils_->ir_builder()->SetInsertPoint(add2_body);
+  llvm::Value* add2_sum = codegen_utils_->ir_builder()->CreateAdd(
       ArgumentByPosition(add2_func, 0),
       ArgumentByPosition(add2_func, 1));
-  code_generator_->ir_builder()->CreateRet(add2_sum);
+  codegen_utils_->ir_builder()->CreateRet(add2_sum);
 
   // Create another function that adds 3 ints by making 2 calls to add2.
   llvm::Function* add3_func
-      = code_generator_->CreateFunction<int, int, int, int>("add3");
-  llvm::BasicBlock* add3_body = code_generator_->CreateBasicBlock("body",
+      = codegen_utils_->CreateFunction<int, int, int, int>("add3");
+  llvm::BasicBlock* add3_body = codegen_utils_->CreateBasicBlock("body",
                                                                   add3_func);
-  code_generator_->ir_builder()->SetInsertPoint(add3_body);
-  llvm::Value* add3_sum1 = code_generator_->ir_builder()->CreateCall(
+  codegen_utils_->ir_builder()->SetInsertPoint(add3_body);
+  llvm::Value* add3_sum1 = codegen_utils_->ir_builder()->CreateCall(
       add2_func,
       {ArgumentByPosition(add3_func, 0), ArgumentByPosition(add3_func, 1)});
-  llvm::Value* add3_sum2 = code_generator_->ir_builder()->CreateCall(
+  llvm::Value* add3_sum2 = codegen_utils_->ir_builder()->CreateCall(
       add2_func,
       {add3_sum1, ArgumentByPosition(add3_func, 2)});
-  code_generator_->ir_builder()->CreateRet(add3_sum2);
+  codegen_utils_->ir_builder()->CreateRet(add3_sum2);
 
   // Before optimization, function memory-access characteristics are not known.
   EXPECT_FALSE(add2_func->doesNotAccessMemory());
   EXPECT_FALSE(add3_func->doesNotAccessMemory());
 
   // Apply basic optimizations.
-  EXPECT_TRUE(code_generator_->Optimize(CodeGenerator::OptimizationLevel::kLess,
-                                        CodeGenerator::SizeLevel::kNormal,
+  EXPECT_TRUE(codegen_utils_->Optimize(CodeGenUtils::OptimizationLevel::kLess,
+                                        CodeGenUtils::SizeLevel::kNormal,
                                         false));
 
   // Analysis passes should have marked both functions "readnone" since they do
@@ -2283,79 +2283,79 @@ TEST_F(CodeGeneratorTest, OptimizationTest) {
   }
 
   // Now, actually compile machine code from the optimized IR and call it.
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kLess,
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kLess,
       false));
   int (*add3_compiled)(int, int, int)
-      = code_generator_->GetFunctionPointer<int, int, int, int>("add3");
+      = codegen_utils_->GetFunctionPointer<int, int, int, int>("add3");
   EXPECT_EQ(758, (*add3_compiled)(12, -67, 813));
 }
 
 // Test code-generation used with instance methods of a statically compiled C++
 // class.
-TEST_F(CodeGeneratorTest, CppClassObjectTest) {
+TEST_F(CodeGenUtilsTest, CppClassObjectTest) {
   // Register method wrappers for Accumulator<double>
   llvm::Function* new_accumulator_double
-      = code_generator_->RegisterExternalFunction(
+      = codegen_utils_->RegisterExternalFunction(
           &WrapNew<Accumulator<double>, double>);
   llvm::Function* delete_accumulator_double
-      = code_generator_->RegisterExternalFunction(
+      = codegen_utils_->RegisterExternalFunction(
           &WrapDelete<Accumulator<double>>);
   llvm::Function* accumulator_double_accumulate
-      = code_generator_->RegisterExternalFunction(
+      = codegen_utils_->RegisterExternalFunction(
           &GPCODEGEN_WRAP_METHOD(&Accumulator<double>::Accumulate));
   llvm::Function* accumulator_double_get
-      = code_generator_->RegisterExternalFunction(
+      = codegen_utils_->RegisterExternalFunction(
           &GPCODEGEN_WRAP_METHOD(&Accumulator<double>::Get));
 
   llvm::Function* accumulate_test_fn
-      = code_generator_->CreateFunction<double, double>("accumulate_test_fn");
+      = codegen_utils_->CreateFunction<double, double>("accumulate_test_fn");
   llvm::BasicBlock* body
-      = code_generator_->CreateBasicBlock("body", accumulate_test_fn);
-  code_generator_->ir_builder()->SetInsertPoint(body);
+      = codegen_utils_->CreateBasicBlock("body", accumulate_test_fn);
+  codegen_utils_->ir_builder()->SetInsertPoint(body);
 
   // Make a new accumulator object, forwarding the function's argument to the
   // constructor.
-  llvm::Value* accumulator_ptr = code_generator_->ir_builder()->CreateCall(
+  llvm::Value* accumulator_ptr = codegen_utils_->ir_builder()->CreateCall(
       new_accumulator_double,
       {ArgumentByPosition(accumulate_test_fn, 0)});
 
   // Add a few constants to the accumulator via the wrapped instance method.
-  code_generator_->ir_builder()->CreateCall(
+  codegen_utils_->ir_builder()->CreateCall(
       accumulator_double_accumulate,
-      {accumulator_ptr, code_generator_->GetConstant(1.0)});
-  code_generator_->ir_builder()->CreateCall(
+      {accumulator_ptr, codegen_utils_->GetConstant(1.0)});
+  codegen_utils_->ir_builder()->CreateCall(
       accumulator_double_accumulate,
-      {accumulator_ptr, code_generator_->GetConstant(2.0)});
-  code_generator_->ir_builder()->CreateCall(
+      {accumulator_ptr, codegen_utils_->GetConstant(2.0)});
+  codegen_utils_->ir_builder()->CreateCall(
       accumulator_double_accumulate,
-      {accumulator_ptr, code_generator_->GetConstant(3.0)});
-  code_generator_->ir_builder()->CreateCall(
+      {accumulator_ptr, codegen_utils_->GetConstant(3.0)});
+  codegen_utils_->ir_builder()->CreateCall(
       accumulator_double_accumulate,
-      {accumulator_ptr, code_generator_->GetConstant(4.0)});
+      {accumulator_ptr, codegen_utils_->GetConstant(4.0)});
 
   // Read out the accumulated value.
-  llvm::Value* retval = code_generator_->ir_builder()->CreateCall(
+  llvm::Value* retval = codegen_utils_->ir_builder()->CreateCall(
       accumulator_double_get,
       {accumulator_ptr});
 
   // Delete the accumulator object.
-  code_generator_->ir_builder()->CreateCall(
+  codegen_utils_->ir_builder()->CreateCall(
       delete_accumulator_double,
       {accumulator_ptr});
 
   // Return the accumulated value.
-  code_generator_->ir_builder()->CreateRet(retval);
+  codegen_utils_->ir_builder()->CreateRet(retval);
 
   // Check that function and module are well-formed, then compile.
   EXPECT_FALSE(llvm::verifyFunction(*accumulate_test_fn));
-  EXPECT_FALSE(llvm::verifyModule(*code_generator_->module()));
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+  EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
 
   double (*accumulate_test_fn_compiled)(double)  // NOLINT(readability/casting)
-      = code_generator_->GetFunctionPointer<double, double>(
+      = codegen_utils_->GetFunctionPointer<double, double>(
           "accumulate_test_fn");
 
   // Actually invoke the function and make sure that the wrapped behavior of
@@ -2367,59 +2367,59 @@ TEST_F(CodeGeneratorTest, CppClassObjectTest) {
 
 #ifdef GPCODEGEN_DEBUG
 
-TEST_F(CodeGeneratorDeathTest, WrongFunctionTypeTest) {
+TEST_F(CodeGenUtilsDeathTest, WrongFunctionTypeTest) {
   // Create a function identical to the one in TrivialCompilationTest, but try
   // GetFunctionPointer() with the wrong type-signature.
   llvm::Function* simple_fn
-      = code_generator_->CreateFunction<int>("simple_fn");
+      = codegen_utils_->CreateFunction<int>("simple_fn");
   llvm::BasicBlock* simple_fn_body
-      = code_generator_->CreateBasicBlock("simple_fn_body", simple_fn);
-  code_generator_->ir_builder()->SetInsertPoint(simple_fn_body);
-  code_generator_->ir_builder()->CreateRet(
-      code_generator_->GetConstant<int>(42));
-  EXPECT_TRUE(code_generator_->PrepareForExecution(
-      CodeGenerator::OptimizationLevel::kNone,
+      = codegen_utils_->CreateBasicBlock("simple_fn_body", simple_fn);
+  codegen_utils_->ir_builder()->SetInsertPoint(simple_fn_body);
+  codegen_utils_->ir_builder()->CreateRet(
+      codegen_utils_->GetConstant<int>(42));
+  EXPECT_TRUE(codegen_utils_->PrepareForExecution(
+      CodeGenUtils::OptimizationLevel::kNone,
       true));
 
-  EXPECT_DEATH(code_generator_->GetFunctionPointer<float>("simple_fn"), "");
+  EXPECT_DEATH(codegen_utils_->GetFunctionPointer<float>("simple_fn"), "");
 }
 
-TEST_F(CodeGeneratorDeathTest, ModifyExternalFunctionTest) {
+TEST_F(CodeGenUtilsDeathTest, ModifyExternalFunctionTest) {
   // Register an external function, then try to add a BasicBlock to it.
   llvm::Function* external_function
-      = code_generator_->RegisterExternalFunction(&std::mktime);
+      = codegen_utils_->RegisterExternalFunction(&std::mktime);
 
-  EXPECT_DEATH(code_generator_->CreateBasicBlock("body", external_function),
+  EXPECT_DEATH(codegen_utils_->CreateBasicBlock("body", external_function),
                "");
 }
 
-TEST_F(CodeGeneratorDeathTest, GetPointerToMemberFromNullBasePointerTest) {
+TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromNullBasePointerTest) {
   // Set up a dummy function and BasicBlock to hold instructions.
   llvm::Function* dummy_fn
-      = code_generator_->CreateFunction<void>("dummy_fn");
+      = codegen_utils_->CreateFunction<void>("dummy_fn");
   llvm::BasicBlock* dummy_fn_body
-      = code_generator_->CreateBasicBlock("dummy_fn_body", dummy_fn);
-  code_generator_->ir_builder()->SetInsertPoint(dummy_fn_body);
+      = codegen_utils_->CreateBasicBlock("dummy_fn_body", dummy_fn);
+  codegen_utils_->ir_builder()->SetInsertPoint(dummy_fn_body);
 
-  EXPECT_DEATH(code_generator_->GetPointerToMember(nullptr,
+  EXPECT_DEATH(codegen_utils_->GetPointerToMember(nullptr,
                                                    &DummyStruct::int_field),
                "");
 }
 
-TEST_F(CodeGeneratorDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
+TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
   // Set up a dummy function and BasicBlock to hold instructions.
   llvm::Function* dummy_fn
-      = code_generator_->CreateFunction<void>("dummy_fn");
+      = codegen_utils_->CreateFunction<void>("dummy_fn");
   llvm::BasicBlock* dummy_fn_body
-      = code_generator_->CreateBasicBlock("dummy_fn_body", dummy_fn);
-  code_generator_->ir_builder()->SetInsertPoint(dummy_fn_body);
+      = codegen_utils_->CreateBasicBlock("dummy_fn_body", dummy_fn);
+  codegen_utils_->ir_builder()->SetInsertPoint(dummy_fn_body);
 
   const int external_int = 42;
-  llvm::Value* external_int_ptr = code_generator_->GetConstant(&external_int);
+  llvm::Value* external_int_ptr = codegen_utils_->GetConstant(&external_int);
 
   // Pointers to structs are expected to be represented as i8*, but here we are
   // passing an i32* pointer.
-  EXPECT_DEATH(code_generator_->GetPointerToMember(external_int_ptr,
+  EXPECT_DEATH(codegen_utils_->GetPointerToMember(external_int_ptr,
                                                    &DummyStruct::int_field),
                "");
 }
@@ -2430,7 +2430,7 @@ TEST_F(CodeGeneratorDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
-  AddGlobalTestEnvironment(new gpcodegen::CodeGeneratorTestEnvironment);
+  AddGlobalTestEnvironment(new gpcodegen::CodeGenUtilsTestEnvironment);
   return RUN_ALL_TESTS();
 }
 

--- a/src/backend/codegen/tests/codegen_utils_unittest.cc
+++ b/src/backend/codegen/tests/codegen_utils_unittest.cc
@@ -95,7 +95,7 @@ struct DummyStruct {
 };
 
 // A dummy struct with several char fields that map to LLVM's i8 type. Used to
-// check that CodeGenUtils::GetPointerToMember() works correctly when the type
+// check that CodegenUtils::GetPointerToMember() works correctly when the type
 // of a pointer to the field to be accessed is the same as the type used for
 // underlying pointer arithmetic.
 struct DummyStructWithCharFields {
@@ -238,21 +238,21 @@ struct ExpectLongLong<EnumT,
 
 // Test environment to handle global per-process initialization tasks for all
 // tests.
-class CodeGenUtilsTestEnvironment : public ::testing::Environment {
+class CodegenUtilsTestEnvironment : public ::testing::Environment {
  public:
   virtual void SetUp() {
-    ASSERT_TRUE(CodeGenUtils::InitializeGlobal());
+    ASSERT_TRUE(CodegenUtils::InitializeGlobal());
   }
 };
 
-class CodeGenUtilsTest : public ::testing::Test {
+class CodegenUtilsTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    codegen_utils_.reset(new CodeGenUtils("test_module"));
+    codegen_utils_.reset(new CodegenUtils("test_module"));
   }
 
-  // Helper method for GetScalarTypeTest. Tests CodeGenUtils::GetType() and
-  // CodeGenUtils::GetAnnotatedType() for an 'IntegerType' and its
+  // Helper method for GetScalarTypeTest. Tests CodegenUtils::GetType() and
+  // CodegenUtils::GetAnnotatedType() for an 'IntegerType' and its
   // const-qualified version.
   template <typename IntegerType>
   void CheckGetIntegerType() {
@@ -294,7 +294,7 @@ class CodeGenUtilsTest : public ::testing::Test {
     EXPECT_FALSE(annotated_type.is_volatile.front());
   }
 
-  // Helper method for GetScalarTypeTest. Tests CodeGenUtils::GetType() for an
+  // Helper method for GetScalarTypeTest. Tests CodegenUtils::GetType() for an
   // 'EnumType' that is expected to map to 'EquivalentIntegerType'.
   template <typename EnumType, typename EquivalentIntegerType>
   void CheckGetEnumType() {
@@ -345,11 +345,11 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerTypeTest. Checks that the annotations produced
-  // by CodeGenUtils::GetAnnotatedType() are as expected for a given
+  // by CodegenUtils::GetAnnotatedType() are as expected for a given
   // 'PointerType' (which may also be a reference).
   //
   // NOTE(chasseur): This works with up to 2 levels of indirection (e.g. pointer
-  // to pointer) which is as far as we test. CodeGenUtils::GetAnnotatedType()
+  // to pointer) which is as far as we test. CodegenUtils::GetAnnotatedType()
   // should work for arbitrarily deep chains of pointers, but this check method
   // only looks at most 2 pointers deep.
   template <typename PointerType>
@@ -465,8 +465,8 @@ class CodeGenUtilsTest : public ::testing::Test {
     }
   }
 
-  // Helper method for GetPointerTypeTest. Calls CodeGenUtils::GetType() and
-  // CodeGenUtils::GetAnnotatedType() for 4 versions of a pointer to
+  // Helper method for GetPointerTypeTest. Calls CodegenUtils::GetType() and
+  // CodegenUtils::GetAnnotatedType() for 4 versions of a pointer to
   // 'PointedType' with various const-qualifiers (regular mutable pointer,
   // pointer to const, const-pointer, and const-pointer to const) and invokes
   // 'check_functor' on the returned llvm::Type*. check_functor's call operator
@@ -564,7 +564,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for a single 'integer_constant'.
+  // CodegenUtils::GetConstant() for a single 'integer_constant'.
   template <typename IntegerType>
   void CheckGetSingleIntegerConstant(const IntegerType integer_constant) {
     llvm::Constant* constant = codegen_utils_->GetConstant(integer_constant);
@@ -588,7 +588,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for an 'IntegerType' with several values
+  // CodegenUtils::GetConstant() for an 'IntegerType' with several values
   // of the specified integer type (0, 1, 123, the maximum, and if signed,
   // -1, -123, and the minimum).
   template <typename IntegerType>
@@ -607,7 +607,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for a single 'fp_constant'.
+  // CodegenUtils::GetConstant() for a single 'fp_constant'.
   template <typename FloatingPointType>
   void CheckGetSingleFloatingPointConstant(
       const FloatingPointType fp_constant) {
@@ -635,7 +635,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for a 'FloatingPointType' with several values
+  // CodegenUtils::GetConstant() for a 'FloatingPointType' with several values
   // of the specified floating point type (positive and negative zero, positive
   // and negative 12.34, the minimum and maximum possible normalized values,
   // the highest-magnitude negative value, the smallest possible nonzero
@@ -659,7 +659,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for a single 'enum_constant'.
+  // CodegenUtils::GetConstant() for a single 'enum_constant'.
   template <typename EnumType>
   void CheckGetSingleEnumConstant(const EnumType enum_constant) {
     llvm::Constant* constant = codegen_utils_->GetConstant(enum_constant);
@@ -689,7 +689,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetScalarConstantTest. Tests
-  // CodeGenUtils::GetConstant() for an 'EnumType' by calling
+  // CodegenUtils::GetConstant() for an 'EnumType' by calling
   // CheckGetSingleEnumConstant() for each constant listed in 'enum_constants'.
   template <typename EnumType>
   void CheckGetEnumConstants(std::initializer_list<EnumType> enum_constants) {
@@ -728,11 +728,11 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerConstantTest. Tests
-  // CodeGenUtils::GetConstant() for 'ptr_constant'. Verifies that the
+  // CodegenUtils::GetConstant() for 'ptr_constant'. Verifies that the
   // pointer Constant returned is the expected type and generates an accessor
   // function that returns the address of the pointer constant, recording the
   // expected address in '*pointer_check_addresses'. After all of the
-  // invocations of this method in a test, CodeGenUtils::PrepareForExecution()
+  // invocations of this method in a test, CodegenUtils::PrepareForExecution()
   // should be called to compile the accessor functions, then
   // FinishCheckingGlobalConstantPointers() should be called to make sure that
   // the accessor functions return the expected addresses.
@@ -750,7 +750,7 @@ class CodeGenUtilsTest : public ::testing::Test {
       EXPECT_TRUE(constant->isNullValue());
     } else {
       // Expect a GlobalVariable. This will be mapped to the actual external
-      // address when CodeGenUtils::PrepareForExecution() is called. For now,
+      // address when CodegenUtils::PrepareForExecution() is called. For now,
       // we generate a function that returns the (constant) address of the
       // GlobalVariable. Later on, we will compile all such functions and check
       // that they return the expected addresses.
@@ -776,7 +776,7 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerConstantTest. Tests
-  // CodeGenUtils::GetConstant() by calling CheckGetSinglePointerConstant()
+  // CodegenUtils::GetConstant() by calling CheckGetSinglePointerConstant()
   // for a 'ScalarType*' pointer pointing to NULL, to stack memory, and to heap
   // memory, and for a 'ScalarType**' pointer pointing to NULL, to stack
   // memory, and to heap memory.
@@ -857,12 +857,12 @@ class CodeGenUtilsTest : public ::testing::Test {
   }
 
   // Helper method for GetPointerToMemberConstantTest. Verifies that
-  // CodeGenUtils::GetPointerToMember() functions correctly for
+  // CodegenUtils::GetPointerToMember() functions correctly for
   // 'pointers_to_members' by checking the type of the pointer generated when
   // accessing a member from a constant pointer to StructType and generating an
   // accessor function the returns the address of the member, recording the
   // expected address in '*pointer_check_addresses'. After all of the
-  // invocations of this method in a test, CodeGenUtils::PrepareForExecution()
+  // invocations of this method in a test, CodegenUtils::PrepareForExecution()
   // should be called to compile the accessor functions, then
   // FinishCheckingGlobalConstantPointers() should be called to make sure that
   // the accessor functions return the expected addresses.
@@ -1016,7 +1016,7 @@ class CodeGenUtilsTest : public ::testing::Test {
 
     // Prepare for execution.
     EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-        CodeGenUtils::OptimizationLevel::kNone, true));
+        CodegenUtils::OptimizationLevel::kNone, true));
 
     void (*project_scalar_function_compiled)(InputType*, InputType*)
          = codegen_utils_->GetFunctionPointer<void, InputType*, InputType*>(
@@ -1035,19 +1035,19 @@ class CodeGenUtilsTest : public ::testing::Test {
     delete[] output_array;
   }
 
-  std::unique_ptr<CodeGenUtils> codegen_utils_;
+  std::unique_ptr<CodegenUtils> codegen_utils_;
 };
 
-typedef CodeGenUtilsTest CodeGenUtilsDeathTest;
+typedef CodegenUtilsTest CodegenUtilsDeathTest;
 
-TEST_F(CodeGenUtilsTest, InitializationTest) {
+TEST_F(CodegenUtilsTest, InitializationTest) {
   EXPECT_NE(codegen_utils_->ir_builder(), nullptr);
   ASSERT_NE(codegen_utils_->module(), nullptr);
   EXPECT_EQ(std::string("test_module"),
             codegen_utils_->module()->getModuleIdentifier());
 }
 
-TEST_F(CodeGenUtilsTest, GetScalarTypeTest) {
+TEST_F(CodegenUtilsTest, GetScalarTypeTest) {
   // Check void.
   llvm::Type* llvm_type = codegen_utils_->GetType<void>();
   ASSERT_NE(llvm_type, nullptr);
@@ -1239,7 +1239,7 @@ TEST_F(CodeGenUtilsTest, GetScalarTypeTest) {
   CheckGetEnumType<StronglyTypedEnumUint64, std::uint64_t>();
 }
 
-TEST_F(CodeGenUtilsTest, GetPointerTypeTest) {
+TEST_F(CodegenUtilsTest, GetPointerTypeTest) {
   // Check void*. Void pointers are a special case, because convention in the
   // LLVM type system is to use i8* (equivalent to char* in C) for all
   // "untyped" pointers.
@@ -1424,7 +1424,7 @@ TEST_F(CodeGenUtilsTest, GetPointerTypeTest) {
           pointer_to_pointer_to_void_check_lambda);
 }
 
-TEST_F(CodeGenUtilsTest, GetScalarConstantTest) {
+TEST_F(CodegenUtilsTest, GetScalarConstantTest) {
   // Check bool constants.
   llvm::Constant* constant = codegen_utils_->GetConstant(false);
   // Verify the constant's type.
@@ -1509,7 +1509,7 @@ TEST_F(CodeGenUtilsTest, GetScalarConstantTest) {
        StronglyTypedEnumUint64::kCaseC});
 }
 
-TEST_F(CodeGenUtilsTest, GetPointerConstantTest) {
+TEST_F(CodegenUtilsTest, GetPointerConstantTest) {
   // Remember the addresses of pointer constants, in order, that we expect check
   // functions to return.
   std::vector<std::uintptr_t> pointer_check_addresses;
@@ -1625,12 +1625,12 @@ TEST_F(CodeGenUtilsTest, GetPointerConstantTest) {
   // the addresses of global variables are as expected.
   EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
   ASSERT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
   FinishCheckingGlobalConstantPointers(pointer_check_addresses);
 }
 
-TEST_F(CodeGenUtilsTest, GetFunctionTypeTest) {
+TEST_F(CodegenUtilsTest, GetFunctionTypeTest) {
   // Simple function with no parameters that returns void.
   llvm::FunctionType* fn_type = codegen_utils_->GetFunctionType<void>();
   ASSERT_NE(fn_type, nullptr);
@@ -1685,7 +1685,7 @@ TEST_F(CodeGenUtilsTest, GetFunctionTypeTest) {
             fn_type->getParamType(2));
 }
 
-TEST_F(CodeGenUtilsTest, TrivialCompilationTest) {
+TEST_F(CodegenUtilsTest, TrivialCompilationTest) {
   // Create an IR function that takes no arguments and returns int.
   llvm::Function* simple_fn
       = codegen_utils_->CreateFunction<int>("simple_fn");
@@ -1706,7 +1706,7 @@ TEST_F(CodeGenUtilsTest, TrivialCompilationTest) {
 
   // Prepare generated code for execution.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
   EXPECT_EQ(nullptr, codegen_utils_->module());
 
@@ -1723,7 +1723,7 @@ TEST_F(CodeGenUtilsTest, TrivialCompilationTest) {
   EXPECT_EQ(42, (*function_ptr)());
 }
 
-TEST_F(CodeGenUtilsTest, ExternalFunctionTest) {
+TEST_F(CodegenUtilsTest, ExternalFunctionTest) {
   // Test a function with overloads for different types (we will explicitly use
   // the version of std::fabs() for doubles).
   MakeWrapperFunction<double, double>(&std::fabs,
@@ -1739,7 +1739,7 @@ TEST_F(CodeGenUtilsTest, ExternalFunctionTest) {
   // functions for execution.
   EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
 
   // Try calling std::fabs() through the generated wrapper.
@@ -1770,7 +1770,7 @@ TEST_F(CodeGenUtilsTest, ExternalFunctionTest) {
   EXPECT_EQ(42, StaticIntWrapper::Get());
 }
 
-TEST_F(CodeGenUtilsTest, RecursionTest) {
+TEST_F(CodegenUtilsTest, RecursionTest) {
   // Test a version of the factorial function that works by recursion.
   llvm::Function* factorial_recursive
       = codegen_utils_->CreateFunction<unsigned, unsigned>(
@@ -1826,7 +1826,7 @@ TEST_F(CodeGenUtilsTest, RecursionTest) {
 
   // Prepare for execution.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
   unsigned (*factorial_recursive_compiled)(unsigned)
       = codegen_utils_->GetFunctionPointer<unsigned, unsigned>(
@@ -1839,7 +1839,7 @@ TEST_F(CodeGenUtilsTest, RecursionTest) {
             (*factorial_recursive_compiled)(7u));
 }
 
-TEST_F(CodeGenUtilsTest, SwitchTest) {
+TEST_F(CodegenUtilsTest, SwitchTest) {
   // Test that generates IR code with a SWITCH statement.
   // It takes a char as input and returns 1 if input = 'A',
   // 2 if input is 'B'; -1 otherwise.
@@ -1914,7 +1914,7 @@ TEST_F(CodeGenUtilsTest, SwitchTest) {
 
   // Prepare for execution.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
 
   int (*switch_function_compiled)(char)  // NOLINT(readability/casting)
@@ -1927,23 +1927,23 @@ TEST_F(CodeGenUtilsTest, SwitchTest) {
   EXPECT_EQ(-1, (*switch_function_compiled)('C'));
 }
 
-TEST_F(CodeGenUtilsTest, ProjectScalarIntArrayTest) {
+TEST_F(CodegenUtilsTest, ProjectScalarIntArrayTest) {
   ProjectScalarArrayTestHelper<int>();
 }
 
-TEST_F(CodeGenUtilsTest, ProjectScalarInt16ArrayTest) {
+TEST_F(CodegenUtilsTest, ProjectScalarInt16ArrayTest) {
   ProjectScalarArrayTestHelper<int16_t>();
 }
 
-TEST_F(CodeGenUtilsTest, ProjectScalarInt64ArrayTest) {
+TEST_F(CodegenUtilsTest, ProjectScalarInt64ArrayTest) {
   ProjectScalarArrayTestHelper<int64_t>();
 }
 
-TEST_F(CodeGenUtilsTest, ProjectScalarCharArrayTest) {
+TEST_F(CodegenUtilsTest, ProjectScalarCharArrayTest) {
   ProjectScalarArrayTestHelper<char>();
 }
 
-TEST_F(CodeGenUtilsTest, IterationTest) {
+TEST_F(CodegenUtilsTest, IterationTest) {
   // Test a version of the factorial function works with an iterative loop.
   llvm::Function* factorial_iterative
       = codegen_utils_->CreateFunction<unsigned, unsigned>(
@@ -2025,7 +2025,7 @@ TEST_F(CodeGenUtilsTest, IterationTest) {
 
   // Prepare for execution.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
   unsigned (*factorial_iterative_compiled)(unsigned)
       = codegen_utils_->GetFunctionPointer<unsigned, unsigned>(
@@ -2070,9 +2070,9 @@ TEST_F(CodeGenUtilsTest, IterationTest) {
       &std::remove_reference<decltype((struct_ptr)->top_element_name)>::type   \
           ::nested_element_name)
 
-// Test for CodeGenUtils::GetPointerToMember() with constant pointers to
+// Test for CodegenUtils::GetPointerToMember() with constant pointers to
 // external structs.
-TEST_F(CodeGenUtilsTest, GetPointerToMemberConstantTest) {
+TEST_F(CodegenUtilsTest, GetPointerToMemberConstantTest) {
   // Remember the addresses of pointer constants, in order, that we expect check
   // functions to return.
   std::vector<std::uintptr_t> pointer_check_addresses;
@@ -2098,7 +2098,7 @@ TEST_F(CodeGenUtilsTest, GetPointerToMemberConstantTest) {
                                                heap_struct.get(),
                                                0);
 
-  // A NULL pointer also works, since CodeGenUtils::GetPointerToMember() only
+  // A NULL pointer also works, since CodegenUtils::GetPointerToMember() only
   // does address computation and doesn't dereference anything.
   GPCODEGEN_TEST_GET_POINTER_TO_STRUCT_ELEMENT(
       static_cast<DummyStruct*>(nullptr),
@@ -2175,7 +2175,7 @@ TEST_F(CodeGenUtilsTest, GetPointerToMemberConstantTest) {
   // expected addresses of member fields.
   EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
   ASSERT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
   FinishCheckingGlobalConstantPointers(pointer_check_addresses);
 }
@@ -2183,7 +2183,7 @@ TEST_F(CodeGenUtilsTest, GetPointerToMemberConstantTest) {
 #undef GPCODEGEN_TEST_GET_POINTER_TO_NESTED_STRUCT_ELEMENT
 #undef GPCODEGEN_TEST_GET_POINTER_TO_STRUCT_ELEMENT
 
-TEST_F(CodeGenUtilsTest, GetPointerToMemberTest) {
+TEST_F(CodegenUtilsTest, GetPointerToMemberTest) {
   // Create some accessor functions that load the value of fields in a struct
   // passed in as a pointer.
   MakeStructMemberAccessorFunction<DummyStruct, int>(
@@ -2199,7 +2199,7 @@ TEST_F(CodeGenUtilsTest, GetPointerToMemberTest) {
   // Check that module is well-formed, then compile.
   EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
 
   int (*Get_DummyStruct_int_field)(const DummyStruct*)
@@ -2235,7 +2235,7 @@ TEST_F(CodeGenUtilsTest, GetPointerToMemberTest) {
   EXPECT_EQ(1e100, (*Get_DummyStruct_double_field)(&test_struct));
 }
 
-TEST_F(CodeGenUtilsTest, OptimizationTest) {
+TEST_F(CodegenUtilsTest, OptimizationTest) {
   // Create an ultra-simple function that just adds 2 ints. We expect this to be
   // automatically inlined at call sites during optimization.
   llvm::Function* add2_func
@@ -2267,8 +2267,8 @@ TEST_F(CodeGenUtilsTest, OptimizationTest) {
   EXPECT_FALSE(add3_func->doesNotAccessMemory());
 
   // Apply basic optimizations.
-  EXPECT_TRUE(codegen_utils_->Optimize(CodeGenUtils::OptimizationLevel::kLess,
-                                        CodeGenUtils::SizeLevel::kNormal,
+  EXPECT_TRUE(codegen_utils_->Optimize(CodegenUtils::OptimizationLevel::kLess,
+                                        CodegenUtils::SizeLevel::kNormal,
                                         false));
 
   // Analysis passes should have marked both functions "readnone" since they do
@@ -2284,7 +2284,7 @@ TEST_F(CodeGenUtilsTest, OptimizationTest) {
 
   // Now, actually compile machine code from the optimized IR and call it.
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kLess,
+      CodegenUtils::OptimizationLevel::kLess,
       false));
   int (*add3_compiled)(int, int, int)
       = codegen_utils_->GetFunctionPointer<int, int, int, int>("add3");
@@ -2293,7 +2293,7 @@ TEST_F(CodeGenUtilsTest, OptimizationTest) {
 
 // Test code-generation used with instance methods of a statically compiled C++
 // class.
-TEST_F(CodeGenUtilsTest, CppClassObjectTest) {
+TEST_F(CodegenUtilsTest, CppClassObjectTest) {
   // Register method wrappers for Accumulator<double>
   llvm::Function* new_accumulator_double
       = codegen_utils_->RegisterExternalFunction(
@@ -2351,7 +2351,7 @@ TEST_F(CodeGenUtilsTest, CppClassObjectTest) {
   EXPECT_FALSE(llvm::verifyFunction(*accumulate_test_fn));
   EXPECT_FALSE(llvm::verifyModule(*codegen_utils_->module()));
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
 
   double (*accumulate_test_fn_compiled)(double)  // NOLINT(readability/casting)
@@ -2367,7 +2367,7 @@ TEST_F(CodeGenUtilsTest, CppClassObjectTest) {
 
 #ifdef GPCODEGEN_DEBUG
 
-TEST_F(CodeGenUtilsDeathTest, WrongFunctionTypeTest) {
+TEST_F(CodegenUtilsDeathTest, WrongFunctionTypeTest) {
   // Create a function identical to the one in TrivialCompilationTest, but try
   // GetFunctionPointer() with the wrong type-signature.
   llvm::Function* simple_fn
@@ -2378,13 +2378,13 @@ TEST_F(CodeGenUtilsDeathTest, WrongFunctionTypeTest) {
   codegen_utils_->ir_builder()->CreateRet(
       codegen_utils_->GetConstant<int>(42));
   EXPECT_TRUE(codegen_utils_->PrepareForExecution(
-      CodeGenUtils::OptimizationLevel::kNone,
+      CodegenUtils::OptimizationLevel::kNone,
       true));
 
   EXPECT_DEATH(codegen_utils_->GetFunctionPointer<float>("simple_fn"), "");
 }
 
-TEST_F(CodeGenUtilsDeathTest, ModifyExternalFunctionTest) {
+TEST_F(CodegenUtilsDeathTest, ModifyExternalFunctionTest) {
   // Register an external function, then try to add a BasicBlock to it.
   llvm::Function* external_function
       = codegen_utils_->RegisterExternalFunction(&std::mktime);
@@ -2393,7 +2393,7 @@ TEST_F(CodeGenUtilsDeathTest, ModifyExternalFunctionTest) {
                "");
 }
 
-TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromNullBasePointerTest) {
+TEST_F(CodegenUtilsDeathTest, GetPointerToMemberFromNullBasePointerTest) {
   // Set up a dummy function and BasicBlock to hold instructions.
   llvm::Function* dummy_fn
       = codegen_utils_->CreateFunction<void>("dummy_fn");
@@ -2406,7 +2406,7 @@ TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromNullBasePointerTest) {
                "");
 }
 
-TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
+TEST_F(CodegenUtilsDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
   // Set up a dummy function and BasicBlock to hold instructions.
   llvm::Function* dummy_fn
       = codegen_utils_->CreateFunction<void>("dummy_fn");
@@ -2430,7 +2430,7 @@ TEST_F(CodeGenUtilsDeathTest, GetPointerToMemberFromWrongTypeBasePointerTest) {
 
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
-  AddGlobalTestEnvironment(new gpcodegen::CodeGenUtilsTestEnvironment);
+  AddGlobalTestEnvironment(new gpcodegen::CodegenUtilsTestEnvironment);
   return RUN_ALL_TESTS();
 }
 

--- a/src/backend/codegen/utils/clang_compiler.cc
+++ b/src/backend/codegen/utils/clang_compiler.cc
@@ -33,7 +33,7 @@
 #include "codegen/utils/temporary_file.h"
 #endif
 
-#include "clang/CodeGen/CodeGenAction.h"
+#include "clang/Codegen/CodegenAction.h"
 #include "clang/Tooling/Tooling.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Module.h"
@@ -255,7 +255,7 @@ std::string ClangCompiler::CppTypeFromAnnotatedType(
 
 std::string ClangCompiler::GenerateExternalFunctionDeclarations() const {
   std::string declarations;
-  for (const CodeGenUtils::NamedExternalFunction& external_fn
+  for (const CodegenUtils::NamedExternalFunction& external_fn
        : code_generator_->named_external_functions_) {
     // Mark extern "C" to avoid name-mangling.
     declarations.append("extern \"C\" ");

--- a/src/backend/codegen/utils/clang_compiler.cc
+++ b/src/backend/codegen/utils/clang_compiler.cc
@@ -26,8 +26,8 @@
 #include <utility>
 #include <vector>
 
+#include "codegen/utils/codegen_utils.h"
 #include "codegen/utils/annotated_type.h"
-#include "codegen/utils/code_generator.h"
 
 #ifdef CODEGEN_HAVE_TEMPORARY_FILE
 #include "codegen/utils/temporary_file.h"
@@ -255,7 +255,7 @@ std::string ClangCompiler::CppTypeFromAnnotatedType(
 
 std::string ClangCompiler::GenerateExternalFunctionDeclarations() const {
   std::string declarations;
-  for (const CodeGenerator::NamedExternalFunction& external_fn
+  for (const CodeGenUtils::NamedExternalFunction& external_fn
        : code_generator_->named_external_functions_) {
     // Mark extern "C" to avoid name-mangling.
     declarations.append("extern \"C\" ");

--- a/src/backend/codegen/utils/codegen_utils.cc
+++ b/src/backend/codegen/utils/codegen_utils.cc
@@ -40,7 +40,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/Value.h"
-#include "llvm/Support/CodeGen.h"
+#include "llvm/Support/Codegen.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"
 #include "llvm/Support/TargetSelect.h"
@@ -58,19 +58,19 @@ namespace {
 // Almost-trivial conversion from Codegen enum for optimization level to the
 // LLVM equivalent.
 inline llvm::CodeGenOpt::Level OptLevelCodegenToLLVM(
-    const CodeGenUtils::OptimizationLevel codegen_opt_level) {
+    const CodegenUtils::OptimizationLevel codegen_opt_level) {
   switch (codegen_opt_level) {
-    case CodeGenUtils::OptimizationLevel::kNone:
+    case CodegenUtils::OptimizationLevel::kNone:
       return llvm::CodeGenOpt::None;
-    case CodeGenUtils::OptimizationLevel::kLess:
+    case CodegenUtils::OptimizationLevel::kLess:
       return llvm::CodeGenOpt::Less;
-    case CodeGenUtils::OptimizationLevel::kDefault:
+    case CodegenUtils::OptimizationLevel::kDefault:
       return llvm::CodeGenOpt::Default;
-    case CodeGenUtils::OptimizationLevel::kAggressive:
+    case CodegenUtils::OptimizationLevel::kAggressive:
       return llvm::CodeGenOpt::Aggressive;
     default: {
       std::fprintf(stderr,
-                   "FATAL: Unrecognized CodeGenUtils::OptimizationLevel\n");
+                   "FATAL: Unrecognized CodegenUtils::OptimizationLevel\n");
       std::exit(1);
     }
   }
@@ -78,17 +78,17 @@ inline llvm::CodeGenOpt::Level OptLevelCodegenToLLVM(
 
 }  // namespace
 
-constexpr char CodeGenUtils::kExternalVariableNamePrefix[];
-constexpr char CodeGenUtils::kExternalFunctionNamePrefix[];
+constexpr char CodegenUtils::kExternalVariableNamePrefix[];
+constexpr char CodegenUtils::kExternalFunctionNamePrefix[];
 
-CodeGenUtils::CodeGenUtils(llvm::StringRef module_name)
+CodegenUtils::CodegenUtils(llvm::StringRef module_name)
     : ir_builder_(context_),
       module_(new llvm::Module(module_name, context_)),
       external_variable_counter_(0),
       external_function_counter_(0) {
 }
 
-bool CodeGenUtils::InitializeGlobal() {
+bool CodegenUtils::InitializeGlobal() {
   // These LLVM initialization routines return true if there is no native
   // target available, false if initialization was OK. So, if all 3 return
   // false, then initialization is fine.
@@ -97,7 +97,7 @@ bool CodeGenUtils::InitializeGlobal() {
          && !llvm::InitializeNativeTargetAsmParser();
 }
 
-bool CodeGenUtils::Optimize(const OptimizationLevel generic_opt_level,
+bool CodegenUtils::Optimize(const OptimizationLevel generic_opt_level,
                              const SizeLevel size_level,
                              const bool optimize_for_host_cpu) {
   // This method's implementation is loosely based on the LLVM "opt"
@@ -200,7 +200,7 @@ bool CodeGenUtils::Optimize(const OptimizationLevel generic_opt_level,
   return true;
 }
 
-bool CodeGenUtils::PrepareForExecution(const OptimizationLevel cpu_opt_level,
+bool CodegenUtils::PrepareForExecution(const OptimizationLevel cpu_opt_level,
                                         const bool optimize_for_host_cpu) {
   if (engine_.get() != nullptr) {
     // This method was already called successfully.
@@ -263,7 +263,7 @@ bool CodeGenUtils::PrepareForExecution(const OptimizationLevel cpu_opt_level,
   return true;
 }
 
-llvm::GlobalVariable* CodeGenUtils::AddExternalGlobalVariable(
+llvm::GlobalVariable* CodegenUtils::AddExternalGlobalVariable(
     llvm::Type* type,
     const void* address) {
   external_global_variables_.emplace_back(
@@ -278,7 +278,7 @@ llvm::GlobalVariable* CodeGenUtils::AddExternalGlobalVariable(
                                   external_global_variables_.back().first);
 }
 
-void CodeGenUtils::CheckFunctionType(
+void CodegenUtils::CheckFunctionType(
     const std::string& function_name,
     const llvm::FunctionType* expected_function_type) {
   // Look up function in the ExecutionEngine if PrepareForExecution() has
@@ -292,7 +292,7 @@ void CodeGenUtils::CheckFunctionType(
   }
 }
 
-std::string CodeGenUtils::GenerateExternalVariableName() {
+std::string CodegenUtils::GenerateExternalVariableName() {
   char print_buffer[sizeof(kExternalVariableNamePrefix)
                     + (sizeof(unsigned) << 1) + 1] = {};
   int chars_printed = std::snprintf(print_buffer,
@@ -304,7 +304,7 @@ std::string CodeGenUtils::GenerateExternalVariableName() {
   return std::string(print_buffer);
 }
 
-std::string CodeGenUtils::GenerateExternalFunctionName() {
+std::string CodegenUtils::GenerateExternalFunctionName() {
   // Prefix for generated names is only 10 chars. Up to 16 chars (including
   // null-terminator) are typically stored inline for C++ standard library
   // implementations that use the short-string optimization for std::string
@@ -326,7 +326,7 @@ std::string CodeGenUtils::GenerateExternalFunctionName() {
   return std::string(print_buffer);
 }
 
-llvm::Value* CodeGenUtils::GetPointerToMemberImpl(
+llvm::Value* CodegenUtils::GetPointerToMemberImpl(
     llvm::Value* base_ptr,
     llvm::Type* cast_type,
     const std::size_t cumulative_offset) {

--- a/src/backend/codegen/utils/examples/materialize_tuple_ex.cc
+++ b/src/backend/codegen/utils/examples/materialize_tuple_ex.cc
@@ -17,7 +17,7 @@
 
 #include <cstdio>
 
-#include "codegen/utils/code_generator.h"
+#include "codegen/utils/codegen_utils.h"
 #include "codegen/utils/utility.h"
 #include "llvm/IR/Verifier.h"
 
@@ -79,23 +79,23 @@ void materializeTuple(char *tuple) {
 // external
 //
 MaterializeTupleFunction
-GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
+GenerateCodeForMaterializeTuple(gpcodegen::CodeGenUtils *codegen_utils) {
 
-  auto irb = code_generator->ir_builder();
+  auto irb = codegen_utils->ir_builder();
   llvm::Function *mt_function =
-      code_generator->CreateFunction<void, char *>("materializeTuple");
+      codegen_utils->CreateFunction<void, char *>("materializeTuple");
 
   // "Constants"
-  llvm::Value *kNumSlots_value = code_generator->GetConstant(kNumSlots);
-  llvm::Value *kOffsets_array = code_generator->GetConstant(kOffsets);
-  llvm::Value *kTypes_array = code_generator->GetConstant(kTypes);
-  llvm::Value *bool_type = code_generator->GetConstant(Types::kBool);
-  llvm::Value *int_type = code_generator->GetConstant(Types::kInt);
+  llvm::Value *kNumSlots_value = codegen_utils->GetConstant(kNumSlots);
+  llvm::Value *kOffsets_array = codegen_utils->GetConstant(kOffsets);
+  llvm::Value *kTypes_array = codegen_utils->GetConstant(kTypes);
+  llvm::Value *bool_type = codegen_utils->GetConstant(Types::kBool);
+  llvm::Value *int_type = codegen_utils->GetConstant(Types::kInt);
   // "External functions"
   llvm::Function *parseInt_f =
-      code_generator->RegisterExternalFunction(ParseInt);
+      codegen_utils->RegisterExternalFunction(ParseInt);
   llvm::Function *parseBool_f =
-      code_generator->RegisterExternalFunction(ParseBool);
+      codegen_utils->RegisterExternalFunction(ParseBool);
 
   /*
    *
@@ -125,19 +125,19 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
 
   // "Blocks"
   llvm::BasicBlock *entry =
-      code_generator->CreateBasicBlock("entry", mt_function);
+      codegen_utils->CreateBasicBlock("entry", mt_function);
   llvm::BasicBlock *loop_start =
-      code_generator->CreateBasicBlock("loop_start", mt_function);
+      codegen_utils->CreateBasicBlock("loop_start", mt_function);
   llvm::BasicBlock *loop_main =
-      code_generator->CreateBasicBlock("loop_main", mt_function);
+      codegen_utils->CreateBasicBlock("loop_main", mt_function);
   llvm::BasicBlock *switch_term =
-      code_generator->CreateBasicBlock("switch_term", mt_function);
+      codegen_utils->CreateBasicBlock("switch_term", mt_function);
   llvm::BasicBlock *switch_bool =
-      code_generator->CreateBasicBlock("switch_bool", mt_function);
+      codegen_utils->CreateBasicBlock("switch_bool", mt_function);
   llvm::BasicBlock *switch_int =
-      code_generator->CreateBasicBlock("switch_int", mt_function);
+      codegen_utils->CreateBasicBlock("switch_int", mt_function);
   llvm::BasicBlock *loop_term =
-      code_generator->CreateBasicBlock("loop_term", mt_function);
+      codegen_utils->CreateBasicBlock("loop_term", mt_function);
 
   // "Input Arguments"
   llvm::Value *tuple_arg =
@@ -149,9 +149,9 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
 
   // loop-start block
   irb->SetInsertPoint(loop_start);
-  llvm::PHINode *kOffsets_index = irb->CreatePHI(code_generator->GetType<int>(),
+  llvm::PHINode *kOffsets_index = irb->CreatePHI(codegen_utils->GetType<int>(),
                                                  2 /* num of incoming edges */);
-  kOffsets_index->addIncoming(code_generator->GetConstant(0), entry);
+  kOffsets_index->addIncoming(codegen_utils->GetConstant(0), entry);
 
   // kOffsets_index == kNumSlots_value
   irb->CreateCondBr(irb->CreateICmpEQ(kOffsets_index, kNumSlots_value),
@@ -161,15 +161,15 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
   irb->SetInsertPoint(loop_main);
   // Type offset_value = kOffsets_array[kOffsets_index]
   llvm::Value *offset_value =
-      irb->CreateLoad(code_generator->ir_builder()->CreateInBoundsGEP(
-          code_generator->GetType<int>(), kOffsets_array, kOffsets_index));
+      irb->CreateLoad(codegen_utils->ir_builder()->CreateInBoundsGEP(
+          codegen_utils->GetType<int>(), kOffsets_array, kOffsets_index));
   // Type type_value = kTypes_array[kOffsets_index]
   llvm::Value *type_value =
-      irb->CreateLoad(code_generator->ir_builder()->CreateInBoundsGEP(
-          code_generator->GetType<Types>(), kTypes_array, kOffsets_index));
+      irb->CreateLoad(codegen_utils->ir_builder()->CreateInBoundsGEP(
+          codegen_utils->GetType<Types>(), kTypes_array, kOffsets_index));
   // char* slot_ptr = tuple_arg[offset_value]
   llvm::Value *slot_ptr = irb->CreateInBoundsGEP(
-      code_generator->GetType<char>(), tuple_arg, offset_value);
+      codegen_utils->GetType<char>(), tuple_arg, offset_value);
 
   // switch(type)
   llvm::SwitchInst *switch_ins = irb->CreateSwitch(type_value, switch_term, 3);
@@ -181,7 +181,7 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
     // *slot_ptr = (char) parseBool_f()
     llvm::Value *parsed_value = irb->CreateCall(parseBool_f, {});
     irb->CreateStore(
-        irb->CreateZExt(parsed_value, code_generator->GetType<char>()),
+        irb->CreateZExt(parsed_value, codegen_utils->GetType<char>()),
         slot_ptr);
     irb->CreateBr(switch_term);
   }
@@ -192,7 +192,7 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
     llvm::Value *parsed_value = irb->CreateCall(parseInt_f, {});
     irb->CreateStore(
         parsed_value,
-        irb->CreateBitCast(slot_ptr, code_generator->GetType<int *>()));
+        irb->CreateBitCast(slot_ptr, codegen_utils->GetType<int *>()));
     irb->CreateBr(switch_term);
   }
 
@@ -201,7 +201,7 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
 
   // kOffsets_index++
   llvm::Value *next_kOffsets_index =
-      irb->CreateAdd(kOffsets_index, code_generator->GetConstant(1));
+      irb->CreateAdd(kOffsets_index, codegen_utils->GetConstant(1));
   irb->CreateBr(loop_start);
   kOffsets_index->addIncoming(next_kOffsets_index, switch_term);
 
@@ -211,27 +211,27 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenerator *code_generator) {
 
   // Verification
   assert(!llvm::verifyFunction(*mt_function));
-  assert(!llvm::verifyModule(*code_generator->module()));
+  assert(!llvm::verifyModule(*codegen_utils->module()));
 
-  bool prepare_ok = code_generator->PrepareForExecution(
-             gpcodegen::CodeGenerator::OptimizationLevel::kDefault, true);
+  bool prepare_ok = codegen_utils->PrepareForExecution(
+             gpcodegen::CodeGenUtils::OptimizationLevel::kDefault, true);
   assert(prepare_ok);
 
-  return code_generator->GetFunctionPointer<void, char *>("materializeTuple");
+  return codegen_utils->GetFunctionPointer<void, char *>("materializeTuple");
 }
 }
 
 int main() {
-  bool init_ok = gpcodegen::CodeGenerator::InitializeGlobal();
+  bool init_ok = gpcodegen::CodeGenUtils::InitializeGlobal();
   assert(init_ok);
 
   std::printf("Testing static compiled version:\n");
-  gpcodegen::CodeGenerator code_generator("materializeTuple");
+  gpcodegen::CodeGenUtils codegen_utils("materializeTuple");
   testMaterializeTuple(materializeTuple);
 
   std::printf("Testing JIT compiled version:\n");
   auto materializeTupleCompiled =
-      GenerateCodeForMaterializeTuple(&code_generator);
+      GenerateCodeForMaterializeTuple(&codegen_utils);
   testMaterializeTuple(materializeTupleCompiled);
   return 0;
 }

--- a/src/backend/codegen/utils/examples/materialize_tuple_ex.cc
+++ b/src/backend/codegen/utils/examples/materialize_tuple_ex.cc
@@ -79,7 +79,7 @@ void materializeTuple(char *tuple) {
 // external
 //
 MaterializeTupleFunction
-GenerateCodeForMaterializeTuple(gpcodegen::CodeGenUtils *codegen_utils) {
+GenerateCodeForMaterializeTuple(gpcodegen::CodegenUtils *codegen_utils) {
 
   auto irb = codegen_utils->ir_builder();
   llvm::Function *mt_function =
@@ -214,7 +214,7 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenUtils *codegen_utils) {
   assert(!llvm::verifyModule(*codegen_utils->module()));
 
   bool prepare_ok = codegen_utils->PrepareForExecution(
-             gpcodegen::CodeGenUtils::OptimizationLevel::kDefault, true);
+             gpcodegen::CodegenUtils::OptimizationLevel::kDefault, true);
   assert(prepare_ok);
 
   return codegen_utils->GetFunctionPointer<void, char *>("materializeTuple");
@@ -222,11 +222,11 @@ GenerateCodeForMaterializeTuple(gpcodegen::CodeGenUtils *codegen_utils) {
 }
 
 int main() {
-  bool init_ok = gpcodegen::CodeGenUtils::InitializeGlobal();
+  bool init_ok = gpcodegen::CodegenUtils::InitializeGlobal();
   assert(init_ok);
 
   std::printf("Testing static compiled version:\n");
-  gpcodegen::CodeGenUtils codegen_utils("materializeTuple");
+  gpcodegen::CodegenUtils codegen_utils("materializeTuple");
   testMaterializeTuple(materializeTuple);
 
   std::printf("Testing JIT compiled version:\n");

--- a/src/include/codegen/init_codegen.h
+++ b/src/include/codegen/init_codegen.h
@@ -18,7 +18,7 @@ extern "C" {
 
 // Do one-time global initialization of Clang and LLVM libraries. Returns 0
 // on success, nonzero on error.
-int InitCodeGen();
+int InitCodegen();
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
Based on the comments from PR:https://github.com/foyzur/gpdb/pull/1 I am creating this pull request which has only rename to class / files in existing codegen/utils.

This rename is done in order to make more sense given our new framework.
